### PR TITLE
chore: add `@types/jest` to `devDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@types/express": "latest",
     "@types/node": "latest",
     "@types/supertest": "latest",
+    "@types/jest": "latest",
     "connect": "latest",
     "cookie": "latest",
     "destr": "latest",

--- a/yarn.lock
+++ b/yarn.lock
@@ -740,7 +740,7 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
-"@types/jest@26.x":
+"@types/jest@26.x", "@types/jest@latest":
   version "26.0.20"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.20.tgz#cd2f2702ecf69e86b586e1f5223a60e454056307"
   integrity sha512-9zi2Y+5USJRxd0FsahERhBwlcvFh6D2GLQnY2FH2BzK8J9s9omvNHIbvABwIluXa0fD8XVKMLTO0aOEuUfACAA==


### PR DESCRIPTION
When I run with `yarn test` , It fails by @types/jest not found. After I add `@types/jest`, It works well.

<details>
  <summary>Click to check error log</summary>

```

PS C:\Users\pcjpc\Documents\h3> npm run test

> h3@0.2.5 test C:\Users\pcjpc\Documents\h3
> yarn lint && jest

yarn run v1.22.10
$ eslint --ext ts .
Done in 2.76s.
 FAIL  test/basic.test.ts       
  ● Test suite failed to run

    test/basic.test.ts:5:1 - error TS2593: Cannot find name 'describe'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --sav

    5 describe.skip('promisifyHandle', () => {
      ~~~~~~~~
    test/basic.test.ts:6:3 - error TS2593: Cannot find name 'test'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-de

    6   test('handles exception', async () => {
        ~~~~
    test/basic.test.ts:8:11 - error TS2304: Cannot find name 'expect'.

    8     await expect(sendReq(h)).rejects.toThrow('oops')
                ~~~~~~
    test/basic.test.ts:11:3 - error TS2593: Cannot find name 'test'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-d

    11   test('handles exception (promise)', async () => {
         ~~~~
    test/basic.test.ts:13:11 - error TS2304: Cannot find name 'expect'.

    13     await expect(sendReq(h)).rejects.toThrow('oops')
                 ~~~~~~

 FAIL  test/error.test.ts
  ● Test suite failed to run

    test/error.test.ts:4:35 - error TS2304: Cannot find name 'jest'.

    4 ; (global.console.error as any) = jest.fn()
                                        ~~~~
    test/error.test.ts:6:1 - error TS2593: Cannot find name 'describe'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --sav

    6 describe('error', () => {
      ~~~~~~~~
    test/error.test.ts:10:3 - error TS2304: Cannot find name 'beforeEach'.

    10   beforeEach(() => {
         ~~~~~~~~~~
    test/error.test.ts:15:3 - error TS2593: Cannot find name 'it'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev

    15   it('logs errors', async () => {
         ~~
    test/error.test.ts:21:5 - error TS2304: Cannot find name 'expect'.

    21     expect(result.status).toBe(422)
           ~~~~~~
    test/error.test.ts:24:3 - error TS2593: Cannot find name 'it'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev

    24   it('returns errors', async () => {
         ~~
    test/error.test.ts:30:5 - error TS2304: Cannot find name 'expect'.

    30     expect(result.status).toBe(422)
           ~~~~~~
    test/error.test.ts:33:3 - error TS2593: Cannot find name 'it'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev

    33   it('can send internal error', async () => {
         ~~
    test/error.test.ts:39:5 - error TS2304: Cannot find name 'expect'.

    39     expect(result.status).toBe(500)
           ~~~~~~
    test/error.test.ts:41:5 - error TS2304: Cannot find name 'expect'.

    41     expect(console.error).toBeCalled()
           ~~~~~~
    test/error.test.ts:43:5 - error TS2304: Cannot find name 'expect'.

    43     expect(JSON.parse(result.text)).toMatchObject({
           ~~~~~~
    test/error.test.ts:49:3 - error TS2593: Cannot find name 'it'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev

    49   it('can send runtime error', async () => {
         ~~
    test/error.test.ts:50:5 - error TS2304: Cannot find name 'jest'.

    50     jest.clearAllMocks()
           ~~~~
    test/error.test.ts:64:5 - error TS2304: Cannot find name 'expect'.

    64     expect(result.status).toBe(400)
           ~~~~~~
    test/error.test.ts:65:5 - error TS2304: Cannot find name 'expect'.

    65     expect(result.type).toMatch('application/json')
           ~~~~~~
    test/error.test.ts:68:5 - error TS2304: Cannot find name 'expect'.

    68     expect(console.error).not.toBeCalled()
           ~~~~~~
    test/error.test.ts:70:5 - error TS2304: Cannot find name 'expect'.

    70     expect(JSON.parse(result.text)).toMatchObject({
           ~~~~~~
    test/error.test.ts:79:3 - error TS2593: Cannot find name 'it'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev

    79   it('can handle errors in promises', async () => {
         ~~
    test/error.test.ts:83:5 - error TS2304: Cannot find name 'expect'.

    83     expect(res.status).toBe(500)
           ~~~~~~

 FAIL  test/e2e.test.ts
  ● Test suite failed to run

    test/e2e.test.ts:7:35 - error TS2304: Cannot find name 'jest'.

    7 ; (global.console.error as any) = jest.fn()
                                        ~~~~
    test/e2e.test.ts:9:1 - error TS2593: Cannot find name 'describe'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-

    9 describe('server', () => {
      ~~~~~~~~
    test/e2e.test.ts:14:3 - error TS2304: Cannot find name 'beforeEach'.

    14   beforeEach(async () => {
         ~~~~~~~~~~
    test/e2e.test.ts:22:3 - error TS2304: Cannot find name 'afterEach'.

    22   afterEach(() => {
         ~~~~~~~~~
    test/e2e.test.ts:26:3 - error TS2593: Cannot find name 'it'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev @

    26   it('can serve requests', async () => {
         ~~
    test/e2e.test.ts:29:5 - error TS2304: Cannot find name 'expect'.

    29     expect(result.text).toBe('sample')
           ~~~~~~
    test/e2e.test.ts:32:3 - error TS2593: Cannot find name 'it'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev @

    32   it('can return 404s', async () => {
         ~~
    test/e2e.test.ts:34:5 - error TS2304: Cannot find name 'expect'.

    34     expect(result.status).toBe(404)
           ~~~~~~
    test/e2e.test.ts:37:3 - error TS2593: Cannot find name 'it'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev @

    37   it('can return 500s', async () => {
         ~~
    test/e2e.test.ts:40:5 - error TS2304: Cannot find name 'expect'.

    40     expect(result.status).toBe(500)
           ~~~~~~

 FAIL  test/utils.test.ts
  ● Test suite failed to run

    test/utils.test.ts:4:1 - error TS2593: Cannot find name 'describe'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --sav

    4 describe('', () => {
      ~~~~~~~~
    test/utils.test.ts:8:3 - error TS2304: Cannot find name 'beforeEach'.

    8   beforeEach(() => {
        ~~~~~~~~~~
    test/utils.test.ts:13:3 - error TS2593: Cannot find name 'describe'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --sa

    13   describe('sendRedirect', () => {
         ~~~~~~~~
    test/utils.test.ts:14:5 - error TS2593: Cannot find name 'it'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev

    14     it('can redirect URLs', async () => {
           ~~
    test/utils.test.ts:18:7 - error TS2304: Cannot find name 'expect'.

    18       expect(result.header.location).toBe('https://google.com')
             ~~~~~~
    test/utils.test.ts:19:7 - error TS2304: Cannot find name 'expect'.

    19       expect(result.header['content-type']).toBe('text/html')
             ~~~~~~
    test/utils.test.ts:23:3 - error TS2593: Cannot find name 'describe'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --sa

    23   describe('useBase', () => {
         ~~~~~~~~
    test/utils.test.ts:24:5 - error TS2593: Cannot find name 'it'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev

    24     it('can prefix routes', async () => {
           ~~
    test/utils.test.ts:28:7 - error TS2304: Cannot find name 'expect'.

    28       expect(result.text).toBe('/test')
             ~~~~~~
    test/utils.test.ts:30:5 - error TS2593: Cannot find name 'it'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev

    30     it('does nothing when not provided a base', async () => {
           ~~
    test/utils.test.ts:34:7 - error TS2304: Cannot find name 'expect'.

    34       expect(result.text).toBe('/api/test')
             ~~~~~~
    test/utils.test.ts:38:3 - error TS2593: Cannot find name 'describe'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --sa

    38   describe('useQuery', () => {
         ~~~~~~~~
    test/utils.test.ts:39:5 - error TS2593: Cannot find name 'it'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev

    39     it('can parse query params', async () => {
           ~~
    test/utils.test.ts:42:9 - error TS2304: Cannot find name 'expect'.

    42         expect(query).toMatchObject({
               ~~~~~~
    test/utils.test.ts:51:7 - error TS2304: Cannot find name 'expect'.

    51       expect(result.text).toBe('200')
             ~~~~~~

 FAIL  test/app.test.ts
  ● Test suite failed to run

    test/app.test.ts:4:1 - error TS2593: Cannot find name 'describe'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-

    4 describe('app', () => {
      ~~~~~~~~
    test/app.test.ts:8:3 - error TS2304: Cannot find name 'beforeEach'.

    8   beforeEach(() => {
        ~~~~~~~~~~
    test/app.test.ts:13:3 - error TS2593: Cannot find name 'it'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev @

    13   it('can return JSON directly', async () => {
         ~~
    test/app.test.ts:17:5 - error TS2304: Cannot find name 'expect'.

    17     expect(res.body).toEqual({ url: '/' })
           ~~~~~~
    test/app.test.ts:20:3 - error TS2593: Cannot find name 'it'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev @

    20   it('can return HTML directly', async () => {
         ~~
    test/app.test.ts:24:5 - error TS2304: Cannot find name 'expect'.

    24     expect(res.text).toBe('<h1>Hello world!</h1>')
           ~~~~~~
    test/app.test.ts:25:5 - error TS2304: Cannot find name 'expect'.

    25     expect(res.header['content-type']).toBe('text/html')
           ~~~~~~
    test/app.test.ts:28:3 - error TS2593: Cannot find name 'it'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev @

    28   it('allows overriding Content-Type', async () => {
         ~~
    test/app.test.ts:35:5 - error TS2304: Cannot find name 'expect'.

    35     expect(res.header['content-type']).toBe('text/xhtml')
           ~~~~~~
    test/app.test.ts:38:3 - error TS2593: Cannot find name 'it'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev @

    38   it('can match simple prefixes', async () => {
         ~~
    test/app.test.ts:43:5 - error TS2304: Cannot find name 'expect'.

    43     expect(res.text).toBe('prefix2')
           ~~~~~~
    test/app.test.ts:46:3 - error TS2593: Cannot find name 'it'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev @

    46   it('can chain .use calls', async () => {
         ~~
    test/app.test.ts:50:5 - error TS2304: Cannot find name 'expect'.

    50     expect(res.text).toBe('prefix2')
           ~~~~~~
    test/app.test.ts:53:3 - error TS2593: Cannot find name 'it'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev @

    53   it('can use async routes', async () => {
         ~~
    test/app.test.ts:64:5 - error TS2304: Cannot find name 'expect'.

    64     expect(res.text).toBe('42')
           ~~~~~~
    test/app.test.ts:67:3 - error TS2593: Cannot find name 'it'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev @

    67   it('can use route arrays', async () => {
         ~~
    test/app.test.ts:74:5 - error TS2304: Cannot find name 'expect'.

    74     expect(responses).toEqual(['valid', 'valid'])
           ~~~~~~
    test/app.test.ts:77:3 - error TS2593: Cannot find name 'it'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev @

    77   it('can use handler arrays', async () => {
         ~~
    test/app.test.ts:87:5 - error TS2304: Cannot find name 'expect'.

    87     expect(response.text).toEqual('valid')
           ~~~~~~
    test/app.test.ts:90:3 - error TS2593: Cannot find name 'it'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev @

    90   it('prohibits use of next() in non-promisified handlers', () => {
         ~~
    test/app.test.ts:95:3 - error TS2593: Cannot find name 'it'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev @

    95   it('handles next() call with no routes matching', async () => {
         ~~
    test/app.test.ts:100:5 - error TS2304: Cannot find name 'expect'.

    100     expect(response.status).toEqual(404)
            ~~~~~~
    test/app.test.ts:103:3 - error TS2593: Cannot find name 'it'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev 

    103   it('can take an object', async () => {
          ~~
    test/app.test.ts:107:5 - error TS2304: Cannot find name 'expect'.

    107     expect(response.text).toEqual('valid')
            ~~~~~~
    test/app.test.ts:110:3 - error TS2593: Cannot find name 'it'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev 

    110   it('can short-circuit route matching', async () => {
          ~~
    test/app.test.ts:115:5 - error TS2304: Cannot find name 'expect'.

    115     expect(response.text).toEqual('done')
            ~~~~~~
    test/app.test.ts:118:3 - error TS2593: Cannot find name 'it'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev 

    118   it('can use a custom matcher', async () => {
          ~~
    test/app.test.ts:122:5 - error TS2304: Cannot find name 'expect'.

    122     expect(res.text).toBe('Is odd!')
            ~~~~~~
    test/app.test.ts:125:5 - error TS2304: Cannot find name 'expect'.

    125     expect(notFound.status).toBe(404)
            ~~~~~~
    test/app.test.ts:128:3 - error TS2593: Cannot find name 'it'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev 

    128   it('can normalise route definitions', async () => {
          ~~
    test/app.test.ts:132:5 - error TS2304: Cannot find name 'expect'.

    132     expect(res.text).toBe('valid')
            ~~~~~~

 FAIL  test/lazy.test.ts
  ● Test suite failed to run

    test/lazy.test.ts:4:34 - error TS2304: Cannot find name 'jest'.

    4 ;(global.console.error as any) = jest.fn()
                                       ~~~~
    test/lazy.test.ts:6:1 - error TS2593: Cannot find name 'describe'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save

    6 describe('lazy loading', () => {
      ~~~~~~~~
    test/lazy.test.ts:10:3 - error TS2304: Cannot find name 'beforeEach'.

    10   beforeEach(() => {
         ~~~~~~~~~~
    test/lazy.test.ts:20:7 - error TS2593: Cannot find name 'it'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev 

    20       it(`can load ${type} handlers lazily from a ${kind}`, async () => {
             ~~
    test/lazy.test.ts:24:9 - error TS2304: Cannot find name 'expect'.

    24         expect(result.text).toBe('lazy')
               ~~~~~~
    test/lazy.test.ts:27:7 - error TS2593: Cannot find name 'it'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev 

    27       it(`can handle ${type} functions that don't return promises from a ${kind}`, async () => {
             ~~
    test/lazy.test.ts:31:9 - error TS2304: Cannot find name 'expect'.

    31         expect(result.text).toBe('lazy')
               ~~~~~~

 FAIL  test/body.test.ts
  ● Test suite failed to run

    test/body.test.ts:4:1 - error TS2593: Cannot find name 'describe'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save

    4 describe('', () => {
      ~~~~~~~~
    test/body.test.ts:8:3 - error TS2304: Cannot find name 'beforeEach'.

    8   beforeEach(() => {
        ~~~~~~~~~~
    test/body.test.ts:13:3 - error TS2593: Cannot find name 'describe'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --sav

    13   describe('useRawBody', () => {
         ~~~~~~~~
    test/body.test.ts:14:5 - error TS2593: Cannot find name 'it'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev 

    14     it('can handle raw string', async () => {
           ~~
    test/body.test.ts:17:9 - error TS2304: Cannot find name 'expect'.

    17         expect(body).toEqual('{"bool":true,"name":"string","number":1}')
               ~~~~~~
    test/body.test.ts:26:7 - error TS2304: Cannot find name 'expect'.

    26       expect(result.text).toBe('200')
             ~~~~~~
    test/body.test.ts:30:3 - error TS2593: Cannot find name 'describe'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --sav

    30   describe('useJSON', () => {
         ~~~~~~~~
    test/body.test.ts:31:5 - error TS2593: Cannot find name 'it'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev 

    31     it('can parse json payload', async () => {
           ~~
    test/body.test.ts:34:9 - error TS2304: Cannot find name 'expect'.

    34         expect(body).toMatchObject({
               ~~~~~~
    test/body.test.ts:47:7 - error TS2304: Cannot find name 'expect'.

    47       expect(result.text).toBe('200')
             ~~~~~~

 FAIL  test/integrations.test.ts
  ● Test suite failed to run

    test/integrations.test.ts:7:1 - error TS2593: Cannot find name 'describe'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm 

    7 describe('integrations with other frameworks', () => {
      ~~~~~~~~
    test/integrations.test.ts:11:3 - error TS2304: Cannot find name 'beforeEach'.

    11   beforeEach(() => {
         ~~~~~~~~~~
    test/integrations.test.ts:16:3 - error TS2593: Cannot find name 'it'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --s

    16   it('can wrap an express instance', async () => {
         ~~
    test/integrations.test.ts:24:5 - error TS2304: Cannot find name 'expect'.

    24     expect(res.body).toEqual({ express: 'works' })
           ~~~~~~
    test/integrations.test.ts:27:3 - error TS2593: Cannot find name 'it'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --s

    27   it('can be used as express middleware', async () => {
         ~~
    test/integrations.test.ts:38:5 - error TS2304: Cannot find name 'expect'.

    38     expect(res.body).toEqual({ url: '/', prop: '42' })
           ~~~~~~
    test/integrations.test.ts:41:3 - error TS2593: Cannot find name 'it'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --s

    41   it('can wrap a connect instance', async () => {
         ~~
    test/integrations.test.ts:51:5 - error TS2304: Cannot find name 'expect'.

    51     expect(res.body).toEqual({ connect: 'works' })
           ~~~~~~
    test/integrations.test.ts:54:3 - error TS2593: Cannot find name 'it'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev @types/mocha` and then 
add `jest` or `mocha` to the types field in your tsconfig.

    54   it('can be used as connect middleware', async () => {
         ~~
    test/integrations.test.ts:66:5 - error TS2304: Cannot find name 'expect'.

    66     expect(res.body).toEqual({ url: '/', prop: '42' })
           ~~~~~~

----------|---------|----------|---------|---------|-------------------
File      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
----------|---------|----------|---------|---------|-------------------
All files |       0 |        0 |       0 |       0 |
----------|---------|----------|---------|---------|-------------------
Test Suites: 8 failed, 8 total
Tests:       0 total
Snapshots:   0 total
Time:        4.486 s
Ran all test suites.
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! h3@0.2.5 test: `yarn lint && jest`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the h3@0.2.5 test script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     C:\Users\pcjpc\AppData\Roaming\npm-cache\_logs\2021-03-16T07_59_11_637Z-debug.log
```
</details>
