### PR TITLE
perf: use only setImmediate

### DIFF
--- a/src/utils/response.ts
+++ b/src/utils/response.ts
@@ -5,12 +5,7 @@ export function send (res: ServerResponse, data: any, type?: string) {
   if (type) {
     defaultContentType(res, type)
   }
-  return new Promise((resolve) => {
-    setImmediate(() => {
-      res.end(data)
-      resolve(undefined)
-    })
-  })
+  return setImmediate(() => res.end(data))
 }
 
 export function defaultContentType (res: ServerResponse, type?: string) {


### PR DESCRIPTION
Related Issue is [How setImmediate improve performance?](https://github.com/unjs/h3/issues/23)


Hello @pi0 . benchmark time again.

I benchmark on 0.2.9. As you see result below, Only setImmediate is faster than Promise with setImmediate.
The slowest result is Promise with setImmediate. and I cannot find to use resolved undefined value.
Where can we use Promisify res.end?

I hope so you can see the results. :)

```bash
0.2.9 Promise with setImmediate
┌─────────┬───────┬───────┬───────┬───────┬──────────┬─────────┬────────┐
│ Stat    │ 2.5%  │ 50%   │ 97.5% │ 99%   │ Avg      │ Stdev   │ Max    │
├─────────┼───────┼───────┼───────┼───────┼──────────┼─────────┼────────┤
│ Latency │ 10 ms │ 21 ms │ 37 ms │ 44 ms │ 21.37 ms │ 8.91 ms │ 292 ms │
└─────────┴───────┴───────┴───────┴───────┴──────────┴─────────┴────────┘
┌───────────┬─────────┬─────────┬─────────┬────────┬────────┬─────────┬─────────┐
│ Stat      │ 1%      │ 2.5%    │ 50%     │ 97.5%  │ Avg    │ Stdev   │ Min     │
├───────────┼─────────┼─────────┼─────────┼────────┼────────┼─────────┼─────────┤
│ Req/Sec   │ 16847   │ 16847   │ 48223   │ 53663  │ 45742  │ 7932.18 │ 16843   │
├───────────┼─────────┼─────────┼─────────┼────────┼────────┼─────────┼─────────┤
│ Bytes/Sec │ 2.98 MB │ 2.98 MB │ 8.54 MB │ 9.5 MB │ 8.1 MB │ 1.4 MB  │ 2.98 MB │
└───────────┴─────────┴─────────┴─────────┴────────┴────────┴─────────┴─────────┘
```


```bash
0.2.9 only setImmediate
┌─────────┬──────┬───────┬───────┬───────┬──────────┬─────────┬────────┐
│ Stat    │ 2.5% │ 50%   │ 97.5% │ 99%   │ Avg      │ Stdev   │ Max    │
├─────────┼──────┼───────┼───────┼───────┼──────────┼─────────┼────────┤
│ Latency │ 8 ms │ 17 ms │ 25 ms │ 30 ms │ 16.79 ms │ 5.84 ms │ 177 ms │
└─────────┴──────┴───────┴───────┴───────┴──────────┴─────────┴────────┘
┌───────────┬────────┬────────┬─────────┬─────────┬─────────┬─────────┬────────┐
│ Stat      │ 1%     │ 2.5%   │ 50%     │ 97.5%   │ Avg     │ Stdev   │ Min    │
├───────────┼────────┼────────┼─────────┼─────────┼─────────┼─────────┼────────┤
│ Req/Sec   │ 29359  │ 29359  │ 60351   │ 61439   │ 57894.2 │ 6401.98 │ 29353  │
├───────────┼────────┼────────┼─────────┼─────────┼─────────┼─────────┼────────┤
│ Bytes/Sec │ 5.2 MB │ 5.2 MB │ 10.7 MB │ 10.9 MB │ 10.2 MB │ 1.13 MB │ 5.2 MB │
└───────────┴────────┴────────┴─────────┴─────────┴─────────┴─────────┴────────┘
```

```bash
0.2.9 only Promise
┌─────────┬───────┬───────┬───────┬───────┬──────────┬─────────┬────────┐
│ Stat    │ 2.5%  │ 50%   │ 97.5% │ 99%   │ Avg      │ Stdev   │ Max    │
├─────────┼───────┼───────┼───────┼───────┼──────────┼─────────┼────────┤
│ Latency │ 10 ms │ 21 ms │ 29 ms │ 31 ms │ 19.28 ms │ 7.27 ms │ 176 ms │
└─────────┴───────┴───────┴───────┴───────┴──────────┴─────────┴────────┘
┌───────────┬────────┬────────┬─────────┬─────────┬─────────┬─────────┬────────┐
│ Stat      │ 1%     │ 2.5%   │ 50%     │ 97.5%   │ Avg     │ Stdev   │ Min    │
├───────────┼────────┼────────┼─────────┼─────────┼─────────┼─────────┼────────┤
│ Req/Sec   │ 26559  │ 26559  │ 51647   │ 56223   │ 50551.4 │ 5240.26 │ 26552  │
├───────────┼────────┼────────┼─────────┼─────────┼─────────┼─────────┼────────┤
│ Bytes/Sec │ 4.7 MB │ 4.7 MB │ 9.14 MB │ 9.95 MB │ 8.95 MB │ 928 kB  │ 4.7 MB │
└───────────┴────────┴────────┴─────────┴─────────┴─────────┴─────────┴────────┘
```


```bash
0.2.9 only process.nextTick
┌─────────┬───────┬───────┬───────┬───────┬──────────┬─────────┬────────┐
│ Stat    │ 2.5%  │ 50%   │ 97.5% │ 99%   │ Avg      │ Stdev   │ Max    │
├─────────┼───────┼───────┼───────┼───────┼──────────┼─────────┼────────┤
│ Latency │ 10 ms │ 21 ms │ 33 ms │ 41 ms │ 19.93 ms │ 8.08 ms │ 169 ms │
└─────────┴───────┴───────┴───────┴───────┴──────────┴─────────┴────────┘
┌───────────┬─────────┬─────────┬────────┬─────────┬─────────┬─────────┬─────────┐
│ Stat      │ 1%      │ 2.5%    │ 50%    │ 97.5%   │ Avg     │ Stdev   │ Min     │
├───────────┼─────────┼─────────┼────────┼─────────┼─────────┼─────────┼─────────┤
│ Req/Sec   │ 22879   │ 22879   │ 50335  │ 54399   │ 48944   │ 5897.72 │ 22868   │
├───────────┼─────────┼─────────┼────────┼─────────┼─────────┼─────────┼─────────┤
│ Bytes/Sec │ 4.05 MB │ 4.05 MB │ 8.9 MB │ 9.63 MB │ 8.66 MB │ 1.04 MB │ 4.05 MB │
└───────────┴─────────┴─────────┴────────┴─────────┴─────────┴─────────┴─────────┘
```
