### PR TITLE
fix: createError fallback to statusMessage

### DIFF
--- a/src/error.ts
+++ b/src/error.ts
@@ -28,7 +28,7 @@ export function createError (input: Partial<H3Error>): H3Error {
     return input
   }
 
-  const err = new H3Error(input.message)
+  const err = new H3Error(input.message ?? input.statusMessage)
 
   if (input.statusCode) {
     err.statusCode = input.statusCode


### PR DESCRIPTION
Currently, when using Nuxt, the createError does not generate meaningful error messages if only `statusMessage` is provided (which I see is more commonly been used in the Nuxt code base)

![image](https://user-images.githubusercontent.com/11247099/123065711-fc8d1800-d441-11eb-9a7f-04aa6c645a49.png)

I would think it could be better to serve `statusMessage` if `message` is not provided. Ideally, maybe we could have better format as ``` `${input.statusCode}: ${input.statusMessage}` ``` but I will leave it for discussions