### PR TITLE
feat: add params matching

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,5 +49,8 @@
     "ts-jest": "latest",
     "typescript": "latest",
     "ufo": "latest"
+  },
+  "dependencies": {
+    "path-to-regexp": "^6.2.0"
   }
 }

--- a/src/types/node.ts
+++ b/src/types/node.ts
@@ -1,3 +1,9 @@
-export type { IncomingMessage, ServerResponse } from 'http'
+import type { IncomingMessage as BaseIncomingMessage } from 'http'
+export type { ServerResponse } from 'http'
 
 export type Encoding = false | 'ascii' | 'utf8' | 'utf-8' | 'utf16le' | 'ucs2' | 'ucs-2' | 'base64' | 'latin1' | 'binary' | 'hex'
+
+export interface IncomingMessage extends BaseIncomingMessage {
+    params?: Record<string, any>
+    originalUrl?: string
+}

--- a/test/params.test.ts
+++ b/test/params.test.ts
@@ -44,7 +44,7 @@ describe('params', () => {
   })
 
   it('can match named regexp params', async () => {
-    app.use('/api/foo([0-9]+)', req => req.params)
+    app.use('/api/:foo([0-9]+)', req => req.params)
     const res = await request.get('/api/1')
     expect(res.body).toEqual({ foo: '1' })
   })

--- a/test/params.test.ts
+++ b/test/params.test.ts
@@ -1,0 +1,51 @@
+import supertest, { SuperTest, Test } from 'supertest'
+import { createApp, App } from '../src'
+
+describe('params', () => {
+  let app: App
+  let request: SuperTest<Test>
+
+  beforeEach(() => {
+    app = createApp({ debug: false })
+    request = supertest(app)
+  })
+
+  it('can match a mandatory param', async () => {
+    app.use('/api/:foo', req => req.params)
+    const res = await request.get('/api/bar')
+
+    expect(res.body).toEqual({ foo: 'bar' })
+  })
+
+  it('can match an optional param', async () => {
+    app.use('/api/:foo?', req => req.params)
+    const res1 = await request.get('/api/bar')
+
+    expect(res1.body).toEqual({ foo: 'bar' })
+
+    const res2 = await request.get('/api')
+
+    expect(res2.body).toEqual({ })
+  })
+
+  it('can match multiple params', async () => {
+    app.use('/api/:foo/:bar', req => req.params)
+    const res = await request.get('/api/bar/foo')
+
+    expect(res.body).toEqual({ foo: 'bar', bar: 'foo' })
+  })
+
+  it('can match numeric params', async () => {
+    app.use('/api/([0-9]+)', req => req.params)
+    const res1 = await request.get('/api/bar')
+    expect(res1.statusCode).toEqual(404)
+    const res2 = await request.get('/api/1')
+    expect(res2.body).toEqual({ 0: '1' })
+  })
+
+  it('can match named regexp params', async () => {
+    app.use('/api/foo([0-9]+)', req => req.params)
+    const res = await request.get('/api/1')
+    expect(res.body).toEqual({ foo: '1' })
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -5540,6 +5540,11 @@ path-to-regexp@0.1.7:
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
   integrity sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=
 
+path-to-regexp@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-6.2.0.tgz#f7b3803336104c346889adece614669230645f38"
+  integrity sha512-f66KywYG6+43afgE/8j/GoiNyygk/bnoCbps++3ErRKsIYkGGupyv07R2Ok5m9i67Iqc+T2g1eAUGUPzWhYTyg==
+
 path-type@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-3.0.0.tgz#cef31dc8e0a1a3bb0d105c0cd97cf3bf47f4e36f"


### PR DESCRIPTION
Hi!
Based on that discussion #4 and on that issue [#872](https://github.com/nuxt/framework/issues/872) on the nuxt/framework repo, I thought I'd give a try to add params matching on h3 to allow for nuxt server API with params, too 🙂

Please discard it if that's not how you wanted to proceed, it's a pleasure to contribute to awesome packages anyway.

PS: I also added some tests and made sure the other tests all passed but I'm not 100% confident my implementation is the most appropriate because I'm a bit confused as to the reason why `req.url` is being reduced to `/`?