### PR TITLE
feat: can respond to streams

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -108,14 +108,13 @@ export function createHandle (stack: Stack, options: AppOptions): PHandle {
         continue
       }
       const val = await layer.handle(req, res)
-      if (res.writableEnded) {
+      if (res.writableEnded || !val) {
         return
       }
       const type = typeof val
       if (type === 'string') {
         return send(res, val, MIMES.html)
       } else if (type === 'object' && val !== undefined) {
-        // Return 'false' and 'null' values as JSON strings
         if (val && val.buffer) {
           return send(res, val)
         } else if (val instanceof Error) {


### PR DESCRIPTION
Hi!
For issue #45, return null in the handle to prevent the default response
```
app.use('/stream', async (req, res) => {
  const result = await fetch('test.mp4')
  result.body.pipe(res)
})
```