### PR TITLE
feat: handle asyncs returning without closing res

### DIFF
--- a/src/handle.ts
+++ b/src/handle.ts
@@ -20,7 +20,7 @@ export function callHandle (handle: Middleware, req: IncomingMessage, res: Serve
     const next = (err?: Error) => err ? reject(err) : resolve(undefined)
     try {
       const returned = handle(req, res, next)
-      if (returned !== undefined) {
+      if (returned !== undefined && !(returned instanceof Promise)) {
         resolve(returned)
       } else {
         res.once('close', next)


### PR DESCRIPTION
refer the analysis in #35

What I am doing in my handler:

```ts
const app = fastify()

export default async function (req: unknown, res: unknown) {
    await app.ready()
    app.server.emit('request', req, res)
}
```