### PR TITLE
fix: don't lowercase routes when normalizing layers

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -136,7 +136,7 @@ function normalizeLayer (layer: InputLayer) {
     layer.promisify = layer.handle.length > 2 /* req, res, next */
   }
   return {
-    route: withoutTrailingSlash(layer.route).toLocaleLowerCase(),
+    route: withoutTrailingSlash(layer.route),
     match: layer.match,
     handle: layer.lazy
       ? lazyHandle(layer.handle as LazyHandle, layer.promisify)


### PR DESCRIPTION
resolves https://github.com/nuxt/framework/issues/2739

We should either not lowercase routes when adding - or we should lowercase them both on adding routes _and_ per-request. I think case sensitivity is a reasonable default, with the possibility (of course) of adding a custom `.match` per-route to allow case insensitivity.