### PR TITLE
fix: allow returning, number and boolean as well

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -114,7 +114,7 @@ export function createHandle (stack: Stack, options: AppOptions): PHandle {
       const type = typeof val
       if (type === 'string') {
         return send(res, val, MIMES.html)
-      } else if (type === 'object' && val !== undefined) {
+      } else if (val !== undefined) {
         // Return 'false' and 'null' values as JSON strings
         if (val && val.buffer) {
           return send(res, val)

--- a/src/app.ts
+++ b/src/app.ts
@@ -114,12 +114,7 @@ export function createHandle (stack: Stack, options: AppOptions): PHandle {
       const type = typeof val
       if (type === 'string') {
         return send(res, val, MIMES.html)
-      } else if (
-        type === 'object' ||
-        type === 'boolean' ||
-        type === 'number'
-      ) {
-        // Return 'false' and 'null' values as JSON strings
+      } else if (type === 'object' || type === 'boolean' || type === 'number' /* IS_JSON */) {
         if (val && val.buffer) {
           return send(res, val)
         } else if (val instanceof Error) {

--- a/src/app.ts
+++ b/src/app.ts
@@ -114,7 +114,12 @@ export function createHandle (stack: Stack, options: AppOptions): PHandle {
       const type = typeof val
       if (type === 'string') {
         return send(res, val, MIMES.html)
-      } else if (['bigint', 'number', 'boolean', 'object'].includes(type)) {
+      } else if (
+        type === 'bigint' ||
+        type === 'number' ||
+        type === 'boolean' ||
+        type === 'object'
+      ) {
         // Return 'false' and 'null' values as JSON strings
         if (val && val.buffer) {
           return send(res, val)

--- a/src/app.ts
+++ b/src/app.ts
@@ -115,7 +115,7 @@ export function createHandle (stack: Stack, options: AppOptions): PHandle {
       if (type === 'string') {
         return send(res, val, MIMES.html)
       } else if (
-        type === 'object'
+        type === 'object' ||
         type === 'boolean' ||
         type === 'number'
       ) {

--- a/src/app.ts
+++ b/src/app.ts
@@ -114,7 +114,7 @@ export function createHandle (stack: Stack, options: AppOptions): PHandle {
       const type = typeof val
       if (type === 'string') {
         return send(res, val, MIMES.html)
-      } else if (val !== undefined) {
+      } else if (['bigint', 'number', 'boolean', 'object'].includes(type)) {
         // Return 'false' and 'null' values as JSON strings
         if (val && val.buffer) {
           return send(res, val)

--- a/src/app.ts
+++ b/src/app.ts
@@ -115,10 +115,9 @@ export function createHandle (stack: Stack, options: AppOptions): PHandle {
       if (type === 'string') {
         return send(res, val, MIMES.html)
       } else if (
-        type === 'bigint' ||
-        type === 'number' ||
-        type === 'boolean' ||
         type === 'object'
+        type === 'boolean' ||
+        type === 'number'
       ) {
         // Return 'false' and 'null' values as JSON strings
         if (val && val.buffer) {


### PR DESCRIPTION
resolves #48

This enables us to send a response for:

* boolean
* number
* bigint

We may wrongly return a response for functions & symbols. Though likely that's a user error rather than something h3 should check for.