### PR TITLE
chore: remove jest.config.js 

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,0 @@
-module.exports = {
-  preset: 'ts-jest',
-  testEnvironment: 'node',
-  collectCoverage: true
-}

--- a/package.json
+++ b/package.json
@@ -23,8 +23,7 @@
     "lint": "eslint --ext ts,mjs,cjs .",
     "profile": "0x -o -D .profile -P 'autocannon -c 100 -p 10 -d 40 http://localhost:$PORT' ./playground/server.cjs",
     "release": "pnpm lint && pnpm test && pnpm build && standard-version && pnpm publish && git push --follow-tags",
-    "test": "vitest run",
-    "coverage": "vitest run --coverage"
+    "test": "vitest run"
   },
   "dependencies": {
     "cookie-es": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "lint": "eslint --ext ts,mjs,cjs .",
     "profile": "0x -o -D .profile -P 'autocannon -c 100 -p 10 -d 40 http://localhost:$PORT' ./playground/server.cjs",
     "release": "pnpm lint && pnpm test && pnpm build && standard-version && pnpm publish && git push --follow-tags",
-    "test": "vitest run"
+    "test": "vitest run",
+    "coverage": "vitest run --coverage"
   },
   "dependencies": {
     "cookie-es": "^0.5.0",


### PR DESCRIPTION
h3 was migrated to vitest but there's still a jest config file that isn't used as far as I could see 