### PR TITLE
chore: ignore .idea folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 dist
 coverage
 .profile
+.idea


### PR DESCRIPTION
.idea folder is used by the jetbrain IDE suite