### PR TITLE
chore(refactor): extracting handle sending logic

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -116,7 +116,8 @@ export function createHandle (stack: Stack, options: AppOptions): PHandle {
         return
       }
       /*
-       * An inferred send is attempted on the return value from this routes handler.
+       * Given the return value from the layer handler, we try and guess the most applicable response to send.
+       * For instance, if the response is an object, we send stringified JSON with the appropriate header.
        */
       const sendPromise = maybeSendInferredResponse(res, val, { jsonSpacing: spacing })
       if (sendPromise) {

--- a/src/app.ts
+++ b/src/app.ts
@@ -124,9 +124,9 @@ export function createHandle (stack: Stack, options: AppOptions): PHandle {
         return sendPromise
       }
       /*
-       * The handler isn't guaranteed to return a value which can be sent,
-       * such as middleware which only modifies response headers.
-       * In these instances we keep attempting to send matched route responses until eventually a 404 will be thrown.
+       * Handlers aren't guaranteed to return a value which can be sent,
+       * such as middleware which only modify response headers.
+       * In these instances we continue on with the next layer.
        */
     }
     if (!res.writableEnded) {

--- a/src/app.ts
+++ b/src/app.ts
@@ -115,10 +115,18 @@ export function createHandle (stack: Stack, options: AppOptions): PHandle {
       if (res.writableEnded) {
         return
       }
+      /*
+       * An inferred send is attempted on the return value from this routes handler.
+       */
       const sendPromise = maybeSendInferredResponse(res, val, { jsonSpacing: spacing })
       if (sendPromise) {
         return sendPromise
       }
+      /*
+       * The handler isn't guaranteed to return a value which can be sent,
+       * such as middleware which only modifies response headers.
+       * In these instances we keep attempting to send matched route responses until eventually a 404 will be thrown.
+       */
     }
     if (!res.writableEnded) {
       throw createError({ statusCode: 404, statusMessage: 'Not Found' })

--- a/src/utils/response.ts
+++ b/src/utils/response.ts
@@ -23,7 +23,7 @@ export function maybeSendInferredResponse (res: ServerResponse, val: any, option
   }
   /*
    * Stream and Buffer input are sent straight away,
-   * implementations will need to provide the Content-Type header for these themselves manually.
+   * implementations will need to provide the Content-Type header themselves.
    */
   if (isStream(val)) {
     return sendStream(res, val)
@@ -32,11 +32,10 @@ export function maybeSendInferredResponse (res: ServerResponse, val: any, option
     return send(res, val)
   }
   /*
-   * Primitive data input is sent when a mime type can be determined.
-   * The mime type will be the set Content-Type header or a guessed the mime type based on the primitive type.
+   * Primitive data is sent when a mime type can be determined.
+   * The mime type will be the value of the Content-Type header or a guessed mime type based on the type value.
    */
   const mime = (res.getHeader('Content-Type') as string|undefined) || guessMimeType(val)
-  // handle known mime types
   if (mime) {
     // ensure we're dealing with a string
     if (typeof val !== 'string') {

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -1,7 +1,7 @@
 import { Readable, Transform } from 'stream'
 import supertest, { SuperTest, Test } from 'supertest'
 import { describe, it, expect, beforeEach } from 'vitest'
-import { createApp, App } from '../src'
+import { createApp, App, MIMES } from '../src'
 
 describe('app', () => {
   let app: App
@@ -61,6 +61,29 @@ describe('app', () => {
     expect(res.status).toBe(500)
   })
 
+  it('can send json stringified', async () => {
+    const payload = {
+      message: 'hello world'
+    }
+    app.use((_req, res) => {
+      res.setHeader('Content-Type', MIMES.json)
+      return JSON.stringify(payload)
+    })
+    const res = await request.get('/')
+
+    expect(res.body).toEqual(payload)
+    expect(res.header['content-type']).toBe(MIMES.json)
+  })
+  it('can send a stringable html object', async () => {
+    app.use((_req, res) => {
+      res.setHeader('Content-Type', MIMES.html)
+      return 12345
+    })
+    const res = await request.get('/')
+
+    expect(res.text).toEqual('12345')
+    expect(res.header['content-type']).toBe(MIMES.html)
+  })
   it('can return HTML directly', async () => {
     app.use(() => '<h1>Hello world!</h1>')
     const res = await request.get('/')

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,6 +1,6 @@
 import supertest, { SuperTest, Test } from 'supertest'
 import { describe, it, expect, beforeEach } from 'vitest'
-import { createApp, App, sendRedirect, useBase, useQuery, useMethod, assertMethod } from '../src'
+import { createApp, App, sendRedirect, useBase, useQuery, useMethod, assertMethod, guessMimeType, MIMES } from '../src'
 
 describe('', () => {
   let app: App
@@ -67,6 +67,27 @@ describe('', () => {
       expect((await request.get('/post')).status).toBe(405)
       expect((await request.post('/post')).status).toBe(200)
       expect((await request.head('/post')).status).toBe(200)
+    })
+  })
+
+  describe('guessMimeType', () => {
+    it('string as html', () => {
+      expect(guessMimeType('test')).toBe(MIMES.html)
+    })
+    it('objects as json', () => {
+      expect(guessMimeType({ test: 'test' })).toBe(MIMES.json)
+    })
+    it('booleans as json', () => {
+      expect(guessMimeType(true)).toBe(MIMES.json)
+    })
+    it('numbers as json', () => {
+      expect(guessMimeType(123)).toBe(MIMES.json)
+    })
+    it('undefined is not matched', () => {
+      expect(guessMimeType(undefined)).toBeUndefined()
+    })
+    it('symbol is not matched', () => {
+      expect(guessMimeType(Symbol('test'))).toBeUndefined()
     })
   })
 })


### PR DESCRIPTION
## **Why?**

The purpose of this PR is to expose to external packages the logic for inferring a handles return value to the send promise. Specifically for my https://github.com/harlan-zw/unrouted package I had copy + pasted the logic for this, I'd like to benefit from upstream fixes with this change (such as the stream addition).

It also provides a more testable API if further mime type inferences were to be made.

## **Side effects**

**The order in which the responses are inferred has changed.** This was for readability, tests are passing so we can assume there should be no logic issues however would be good to review. Not too sure about performance considerations.

**Edge case fix: HTML content type for primitives** Not something I'd expect to come up outside of an edge case, but if a user wanted to explicitly return a number that should be HTML, they would need to cast it as a string (see tests). 