### PR TITLE
feat!: opt-in using event format using `defineEventHandler`

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -121,7 +121,7 @@ export function createHandle (stack: Stack, options: AppOptions): PHandle {
       } else if (isStream(val)) {
         return sendStream(res, val)
       } else if (type === 'object' || type === 'boolean' || type === 'number' /* IS_JSON */) {
-        if (val && val.buffer) {
+        if (val && (val as Buffer).buffer) {
           return send(res, val)
         } else if (val instanceof Error) {
           throw createError(val)

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,14 +1,16 @@
 import { withoutTrailingSlash } from 'ufo'
-import type { IncomingMessage, ServerResponse } from './types/node'
 import { lazyHandle, promisifyHandle } from './handle'
-import type { Handle, LazyHandle, Middleware, PHandle } from './handle'
+import { toEventHandler, createEvent } from './event'
 import { createError, sendError } from './error'
 import { send, sendStream, isStream, MIMES } from './utils'
+import type { IncomingMessage, ServerResponse } from './types/node'
+import type { Handle, LazyHandle, Middleware, PHandle } from './handle'
+import type { H3EventHandler } from './event'
 
 export interface Layer {
   route: string
   match?: Matcher
-  handle: Handle
+  handler: H3EventHandler
 }
 
 export type Stack = Layer[]
@@ -92,6 +94,8 @@ export function use (
 export function createHandle (stack: Stack, options: AppOptions): PHandle {
   const spacing = options.debug ? 2 : undefined
   return async function handle (req: IncomingMessage, res: ServerResponse) {
+    const event = createEvent(req, res)
+
     // @ts-ignore express/connect compatibility
     req.originalUrl = req.originalUrl || req.url || '/'
     const reqUrl = req.url || '/'
@@ -107,7 +111,7 @@ export function createHandle (stack: Stack, options: AppOptions): PHandle {
       if (layer.match && !layer.match(req.url as string, req)) {
         continue
       }
-      const val = await layer.handle(req, res)
+      const val = await layer.handler(event)
       if (res.writableEnded) {
         return
       }
@@ -132,15 +136,18 @@ export function createHandle (stack: Stack, options: AppOptions): PHandle {
   }
 }
 
-function normalizeLayer (layer: InputLayer) {
-  if (layer.promisify === undefined) {
-    layer.promisify = layer.handle.length > 2 /* req, res, next */
+function normalizeLayer (input: InputLayer) {
+  if (input.promisify === undefined) {
+    input.promisify = input.handle.length > 2 /* req, res, next */
   }
+
+  const handle = input.lazy
+    ? lazyHandle(input.handle as LazyHandle, input.promisify)
+    : (input.promisify ? promisifyHandle(input.handle) : input.handle)
+
   return {
-    route: withoutTrailingSlash(layer.route),
-    match: layer.match,
-    handle: layer.lazy
-      ? lazyHandle(layer.handle as LazyHandle, layer.promisify)
-      : (layer.promisify ? promisifyHandle(layer.handle) : layer.handle)
+    route: withoutTrailingSlash(input.route),
+    match: input.match,
+    handler: toEventHandler(handle)
   }
 }

--- a/src/event.ts
+++ b/src/event.ts
@@ -1,0 +1,48 @@
+import type { IncomingMessage, ServerResponse } from './types/node'
+import type { Handle, Middleware } from './handle'
+
+export interface H3Event {
+  req: IncomingMessage
+  res: ServerResponse,
+  next?: (err?: Error) => void
+}
+
+export type _JSONValue<T=string|number|boolean> = T | T[] | Record<string, T>
+export type JSONValue = _JSONValue<_JSONValue>
+export type H3Response = void | JSONValue | Buffer
+
+export interface H3EventHandler {
+  __is_handler__?: true
+  (event: H3Event): H3Response| Promise<H3Response>
+}
+
+export function defineEventHandler (handler: H3EventHandler) {
+  handler.__is_handler__ = true
+  return handler
+}
+
+export function isEventHandler (handler: H3EventHandler | Handle | Middleware): handler is H3EventHandler {
+  return '__is_handler__' in handler
+}
+
+export function toEventHandler (handler: H3EventHandler | Handle | Middleware): H3EventHandler {
+  if (isEventHandler(handler)) {
+    return handler
+  }
+  if (handler.length > 2) {
+    return defineEventHandler((event) => {
+      return (handler as Middleware)(event.req, event.res, event.next!)
+    })
+  } else {
+    return defineEventHandler((event) => {
+      return (handler as Handle)(event.req, event.res)
+    })
+  }
+}
+
+export function createEvent (req: IncomingMessage, res: ServerResponse): H3Event {
+  return {
+    req,
+    res
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export * from './app'
 export * from './error'
+export * from './event'
 export * from './handle'
 export * from './utils'
 export * from './router'


### PR DESCRIPTION
A bit of context: #73

This refactor, is starting point to move away from `(req, res)` signature to `(event)` format with utilities with minimum possible changes to both core and usage. event is still a simple function `{ req, res }`. 

Tests are untouched and handlers will be automatically upgraded with a wrapper to event format, unless directly opting in an using `defineEventHandler`. Still using a semver-minor to alert about potential behavior changes.

```js
// Keeps working
app.use((req, res) => 'Hello World!')

// Opt-in to new event format
import { defineEventHandler } from 'h3'

app.use(defineEventHandler(() => 'Hello World'))
```
