### PR TITLE
chore(CHANGELOG): remove link to emoji svg inside "handler"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,7 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### ⚠ BREAKING CHANGES
 
-* All `handle` exports and properties are renamed to `hanhttps://assets.grammarly.com/emoji/v1/1f610.svgdler` with some backward compatibilities.
+* All `handle` exports and properties are renamed to `handler` with some backward compatibilities.
 * Legacy handlers are promisified by default
 * opt-in using event format using `defineEventHandler` (#74)
 


### PR DESCRIPTION
a link to the following emoji (😐) looks like it was accidentally pasted in-between the word "handler"

