### PR TITLE
fix(types): fix JSONValue type

### DIFF
--- a/src/event.ts
+++ b/src/event.ts
@@ -12,11 +12,8 @@ export interface H3Event {
 
 export type CompatibilityEvent = H3Event | IncomingMessage
 
-interface JSONObject {
-  [x: string]: JSONValue;
-}
+interface JSONObject { [x: string]: JSONValue }
 interface JSONArray extends Array<JSONValue> { }
-
 export type JSONValue =
   | string
   | number

--- a/src/event.ts
+++ b/src/event.ts
@@ -12,8 +12,17 @@ export interface H3Event {
 
 export type CompatibilityEvent = H3Event | IncomingMessage
 
-type _JSONValue<T=string|number|boolean> = T | T[] | Record<string, T>
-export type JSONValue = _JSONValue<_JSONValue>
+interface JSONObject {
+  [x: string]: JSONValue;
+}
+interface JSONArray extends Array<JSONValue> { }
+
+export type JSONValue =
+  | string
+  | number
+  | boolean
+  | JSONObject
+  | JSONArray
 
 type _H3Response = void | JSONValue | Buffer
 export type H3Response = _H3Response | Promise<_H3Response>

--- a/src/event.ts
+++ b/src/event.ts
@@ -14,12 +14,7 @@ export type CompatibilityEvent = H3Event | IncomingMessage
 
 interface JSONObject { [x: string]: JSONValue }
 interface JSONArray extends Array<JSONValue> { }
-export type JSONValue =
-  | string
-  | number
-  | boolean
-  | JSONObject
-  | JSONArray
+export type JSONValue = string | number | boolean | JSONObject | JSONArray
 
 type _H3Response = void | JSONValue | Buffer
 export type H3Response = _H3Response | Promise<_H3Response>


### PR DESCRIPTION
https://www.typescriptlang.org/play?#code/PTAEDsFMHcCgEtwBdICcBmBDAxpUApAZQHkA5YgIwCtJslQBvWUUAbQA8AuUAZyVUQBzALrciZAGqYANgFdIAblgBfBMjRZcBEqQCCqVJgCeoSOxTgAJj1D7DRgDzjSUuZAB8jUKthmADgD2qPRIRn54zq7yoAC8zKAAPrz8QvFJ4LIAthRoaaAUAQHSkJjgec6UNHTlOnbGsLAgoADCsgaQyLCh4aAA+pEy8g4AKjF8AuCCCRnZaAkFRSXgnjGgw4lrrMIbAEq0QZYO40IANGvuvuyBwaDdETpRkMTSlrF9A24O-Q+DHg2w2AC4D4oEwYh+bjeTBYYNAAHJjpM4Sd4hRuKwGKB0IVuAiUkjvMIVA0mgBRAxBAFAkFo7SSX7PV6raGg3GIwTI1HozHYgJs-EcwnEoA

The current type does not handle nested object/array correctly

Close #104

Edit: oh it conflicts with #105, feel free to pick one you prefer :)