### PR TITLE
feat: add `H3EventContext` for augmentation

### DIFF
--- a/src/event.ts
+++ b/src/event.ts
@@ -2,12 +2,14 @@ import type http from 'http'
 import type { IncomingMessage, ServerResponse, Handler, Middleware } from './types'
 import { callHandler } from './handler'
 
+export interface EventContext extends Record<string, any> {}
+
 export interface H3Event {
   '__is_event__': true
   event: H3Event
   req: IncomingMessage
   res: ServerResponse
-  context: Record<string, any>
+  context: EventContext
 }
 
 export type CompatibilityEvent = H3Event | IncomingMessage

--- a/src/event.ts
+++ b/src/event.ts
@@ -9,7 +9,7 @@ export interface H3Event {
   event: H3Event
   req: IncomingMessage
   res: ServerResponse
-  context: EventContext
+  context: H3EventContext
 }
 
 export type CompatibilityEvent = H3Event | IncomingMessage

--- a/src/event.ts
+++ b/src/event.ts
@@ -2,7 +2,7 @@ import type http from 'http'
 import type { IncomingMessage, ServerResponse, Handler, Middleware } from './types'
 import { callHandler } from './handler'
 
-export interface EventContext extends Record<string, any> {}
+export interface H3EventContext extends Record<string, any> {}
 
 export interface H3Event {
   '__is_event__': true


### PR DESCRIPTION
Simply exposes an `EventContext` interface for manual typing:

```ts
declare module 'h3' {
  interface EventContext {
    myProperty?: boolean
  }
}
export {}
```

resolves #122