### PR TITLE
fix(pkg): add `types` to the exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "sideEffects": false,
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs"
     }


### PR DESCRIPTION
in node16/nodenext module mode of TyepScript 4.7+, If package has `exports` entry on package.json, needs "types" field in `exports.*` for find typings.

ref. https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/