### PR TITLE
fix: ensure `useBase` returns a leading-slash-prefixed url

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -1,4 +1,4 @@
-import { withoutTrailingSlash, withoutBase } from 'ufo'
+import { withoutTrailingSlash, withoutBase, withLeadingSlash } from 'ufo'
 import { createError } from './error'
 import type { Handler, PromisifiedHandler, Middleware, IncomingMessage, ServerResponse, LazyHandler } from './types'
 
@@ -64,7 +64,7 @@ export function useBase (base: string, handler: Handler): Handler {
   if (!base) { return handler }
   return function (req, res) {
     (req as any).originalUrl = (req as any).originalUrl || req.url || '/'
-    req.url = withoutBase(req.url || '/', base)
+    req.url = withLeadingSlash(withoutBase(req.url || '/', base))
     return handler(req, res)
   }
 }


### PR DESCRIPTION
I'd prefer to resolve upstream in `ufo` but I wasn't sure what the desired behaviour of `withoutBase` should be, so this is more of a conversation starter.

Personally I think it is more intuitive that `/api` doesn't remove itself from `/api-test` but only from `/api/test` and `/api?test`, particularly as the _reverse_ behaviour (`withBase`) joins segments with `/`... If you agree, I'll implement in `ufo` directly, and also ensure that `withoutBase` returns `/`-prefixed paths.

see https://github.com/nuxt/framework/issues/5242