### PR TITLE
feat(createError): support `fatal` and `unhandled`

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -58,14 +58,20 @@ export function createApp (options: AppOptions = {}): App {
     const event = createEvent(req, res)
     try {
       await handler(event)
-    } catch (err) {
+    } catch (_error: any) {
+      const error = createError(_error)
+      if (!isError(_error)) {
+        error.unhandled = true
+      }
+
+      if (error.unhandled || error.fatal) {
+        console.error('[h3]', error.fatal ? '[fatal]' : '[unhandled]', error) // eslint-disable-line no-console
+      }
+
       if (options.onError) {
-        await options.onError(err as Error, event)
+        await options.onError(error, event)
       } else {
-        if (!isError(err)) {
-          console.error('[h3]', err) // eslint-disable-line no-console
-        }
-        await sendError(event, err as Error, !!options.debug)
+        await sendError(event, error, !!options.debug)
       }
     }
   }

--- a/src/error.ts
+++ b/src/error.ts
@@ -7,12 +7,16 @@ import { MIMES } from './utils'
  * @extends Error
  * @property {Number} statusCode An Integer indicating the HTTP response status code.
  * @property {String} statusMessage A String representing the HTTP status message
+ * @property {String} fatal Indicates if the error is a fatal error.
+ * @property {String} unhandled Indicates if the error was unhandled and auto captured.
  * @property {Any} data An extra data that will includes in the response.<br>
  *  This can be used to pass additional information about the error.
  * @property {Boolean} internal Setting this property to <code>true</code> will mark error as an internal error
  */
 export class H3Error extends Error {
   statusCode: number = 500
+  fatal: boolean = false
+  unhandled: boolean = false
   statusMessage: string = 'Internal Server Error'
   data?: any
 }
@@ -34,17 +38,11 @@ export function createError (input: string | Partial<H3Error>): H3Error {
 
   const err = new H3Error(input.message ?? input.statusMessage, input.cause ? { cause: input.cause } : undefined)
 
-  if (input.statusCode) {
-    err.statusCode = input.statusCode
-  }
-
-  if (input.statusMessage) {
-    err.statusMessage = input.statusMessage
-  }
-
-  if (input.data) {
-    err.data = input.data
-  }
+  if (input.statusCode) { err.statusCode = input.statusCode }
+  if (input.statusMessage) { err.statusMessage = input.statusMessage }
+  if (input.data) { err.data = input.data }
+  if (input.fatal !== undefined) { err.fatal = input.fatal }
+  if (input.unhandled !== undefined) { err.unhandled = input.unhandled }
 
   return err
 }


### PR DESCRIPTION
- Support `createError({ fatal: true })` and `createError({ unhandled: true })`.
- Always normalize unhandled errors in the app stack and add `unhandled` when it was thrown as a plain error.