### PR TITLE
refactor: deprecate utils with `use*` prefix

### DIFF
--- a/src/utils/body.ts
+++ b/src/utils/body.ts
@@ -15,7 +15,7 @@ const PayloadMethods: HTTPMethod[] = ['PATCH', 'POST', 'PUT', 'DELETE']
  *
  * @return {String|Buffer} Encoded raw string or raw Buffer of the body
  */
-export function useRawBody (event: CompatibilityEvent, encoding: Encoding = 'utf-8'): Encoding extends false ? Buffer : Promise<string | Buffer> {
+export function readRawBody (event: CompatibilityEvent, encoding: Encoding = 'utf-8'): Encoding extends false ? Buffer : Promise<string | Buffer> {
   // Ensure using correct HTTP method before attempt to read payload
   assertMethod(event, PayloadMethods)
 
@@ -40,6 +40,9 @@ export function useRawBody (event: CompatibilityEvent, encoding: Encoding = 'utf
   return encoding ? promise.then(buff => buff.toString(encoding)) : promise
 }
 
+/** @deprecated Use `h3.readRawBody` */
+export const useRawBody = readRawBody
+
 /**
  * Reads request body and try to safely parse using [destr](https://github.com/unjs/destr)
  * @param event {CompatibilityEvent} H3 event or req passed by h3 handler
@@ -51,13 +54,13 @@ export function useRawBody (event: CompatibilityEvent, encoding: Encoding = 'utf
  * const body = await useBody(req)
  * ```
  */
-export async function useBody<T=any> (event: CompatibilityEvent): Promise<T> {
+export async function readBody<T=any> (event: CompatibilityEvent): Promise<T> {
   if (ParsedBodySymbol in event.req) {
     return (event.req as any)[ParsedBodySymbol]
   }
 
   // TODO: Handle buffer
-  const body = await useRawBody(event) as string
+  const body = await readRawBody(event) as string
 
   if (event.req.headers['content-type'] === 'application/x-www-form-urlencoded') {
     const parsedForm = Object.fromEntries(new URLSearchParams(body))
@@ -68,3 +71,6 @@ export async function useBody<T=any> (event: CompatibilityEvent): Promise<T> {
   (event.req as any)[ParsedBodySymbol] = json
   return json
 }
+
+/** @deprecated Use `h3.readBody` */
+export const useBody = readBody

--- a/src/utils/cookie.ts
+++ b/src/utils/cookie.ts
@@ -8,12 +8,15 @@ import { appendHeader } from './response'
  * @param event {CompatibilityEvent} H3 event or req passed by h3 handler
  * @returns Object of cookie name-value pairs
  * ```ts
- * const cookies = useCookies(req)
+ * const cookies = parseCookies(event)
  * ```
  */
-export function useCookies (event: CompatibilityEvent): Record<string, string> {
+export function parseCookies (event: CompatibilityEvent): Record<string, string> {
   return parse(event.req.headers.cookie || '')
 }
+
+/** @deprecated Use `h3.parseCookies` */
+export const useCookies = parseCookies
 
 /**
  * Get a cookie value by name.
@@ -24,9 +27,12 @@ export function useCookies (event: CompatibilityEvent): Record<string, string> {
  * const authorization = useCookie(request, 'Authorization')
  * ```
  */
-export function useCookie (event: CompatibilityEvent, name: string): string | undefined {
-  return useCookies(event)[name]
+export function getCookie (event: CompatibilityEvent, name: string): string | undefined {
+  return parseCookies(event)[name]
 }
+
+/** @deprecated Use `h3.getCookie` */
+export const useCookie = getCookie
 
 /**
  * Set a cookie value by name.

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -1,18 +1,24 @@
-import { getQuery } from 'ufo'
+import { getQuery as _getQuery } from 'ufo'
 import { createError } from '../error'
 import type { HTTPMethod } from '../types'
 import type { CompatibilityEvent } from '../event'
 
-export function useQuery (event: CompatibilityEvent) {
-  return getQuery(event.req.url || '')
+export function getQuery (event: CompatibilityEvent) {
+  return _getQuery(event.req.url || '')
 }
 
-export function useMethod (event: CompatibilityEvent, defaultMethod: HTTPMethod = 'GET'): HTTPMethod {
+/** @deprecated Use `h3.getQuery` */
+export const useQuery = getQuery
+
+export function getMethod (event: CompatibilityEvent, defaultMethod: HTTPMethod = 'GET'): HTTPMethod {
   return (event.req.method || defaultMethod).toUpperCase() as HTTPMethod
 }
 
+/** @deprecated Use `h3.getMethod` */
+export const useMethod = getMethod
+
 export function isMethod (event: CompatibilityEvent, expected: HTTPMethod | HTTPMethod[], allowHead?: boolean) {
-  const method = useMethod(event)
+  const method = getMethod(event)
 
   if (allowHead && method === 'HEAD') {
     return true


### PR DESCRIPTION
`use*` prefix is usually used for composables with context. Using more semantic prefixes instead by deprecating old ones.

- `useRawBody` => `readRawBody`
- `useBody` => `readBody`
- `useCookies` => `parseCookies`
- `useCookie` => `getCookie`
- `useQuery` => `getQuery`
- `useMethod` => `getMethod`