### PR TITLE
feat: add utilities for http headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,9 @@ Instead of adding helpers to `req` and `res`, h3 exposes them as composable util
 - `useQuery(req)`
 - `send(res, data, type?)`
 - `sendRedirect(res, location, code=302)`
+- `getHeaders(req)`
+- `getHeader(req, name)`
+- `setHeader(res, name, value)`
 - `appendHeader(res, name, value)`
 - `createError({ statusCode, statusMessage, data? })`
 - `sendError(res, error, debug?)`

--- a/README.md
+++ b/README.md
@@ -123,10 +123,12 @@ Instead of adding helpers to `req` and `res`, h3 exposes them as composable util
 - `useQuery(req)`
 - `send(res, data, type?)`
 - `sendRedirect(res, location, code=302)`
-- `getHeaders(req)`
-- `getHeader(req, name)`
-- `setHeader(res, name, value)`
-- `appendHeader(res, name, value)`
+- `getRequestHeaders(event, headers)` (alias: `getHeaders`)
+- `getRequestHeader(event, name)` (alias: `getHeader`)
+- `setResponseHeaders(event, headers)` (alias: `setHeaders`)
+- `setResponseHeader(event, name, value)` (alias: `setHeader`)
+- `appendResponseHeaders(event, headers)` (alias: `appendHeaders`)
+- `appendResponseHeader(event, name, value)` (alias: `appendHeader`)
 - `createError({ statusCode, statusMessage, data? })`
 - `sendError(res, error, debug?)`
 - `defineHandle(handle)`

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -1,3 +1,5 @@
+import { IncomingMessage } from 'http'
+import type { IncomingHttpHeaders } from 'http'
 import { getQuery as _getQuery } from 'ufo'
 import { createError } from '../error'
 import type { HTTPMethod } from '../types'
@@ -42,4 +44,17 @@ export function assertMethod (event: CompatibilityEvent, expected: HTTPMethod | 
       statusMessage: 'HTTP method is not allowed.'
     })
   }
+}
+
+export function getHeaders (event: CompatibilityEvent): IncomingHttpHeaders {
+  return event instanceof IncomingMessage
+    ? event.headers
+    : event.req.headers
+}
+
+export function getHeader (event: CompatibilityEvent, name: string): IncomingHttpHeaders[string] {
+  const headers = getHeaders(event)
+  const value = headers[name.toLowerCase()]
+
+  return value
 }

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -1,5 +1,3 @@
-import { IncomingMessage } from 'http'
-import type { IncomingHttpHeaders } from 'http'
 import { getQuery as _getQuery } from 'ufo'
 import { createError } from '../error'
 import type { HTTPMethod } from '../types'
@@ -46,15 +44,17 @@ export function assertMethod (event: CompatibilityEvent, expected: HTTPMethod | 
   }
 }
 
-export function getHeaders (event: CompatibilityEvent): IncomingHttpHeaders {
-  return event instanceof IncomingMessage
-    ? event.headers
-    : event.req.headers
+export function getRequestHeaders (event: CompatibilityEvent): CompatibilityEvent['req']['headers'] {
+  return event.req.headers
 }
 
-export function getHeader (event: CompatibilityEvent, name: string): IncomingHttpHeaders[string] {
-  const headers = getHeaders(event)
+export const getHeaders = getRequestHeaders
+
+export function getRequestHeader (event: CompatibilityEvent, name: string): CompatibilityEvent['req']['headers'][string] {
+  const headers = getRequestHeaders(event)
   const value = headers[name.toLowerCase()]
 
   return value
 }
+
+export const getHeader = getRequestHeader

--- a/src/utils/response.ts
+++ b/src/utils/response.ts
@@ -1,3 +1,4 @@
+import type { OutgoingMessage } from 'http'
 import { createError } from '../error'
 import type { CompatibilityEvent } from '../event'
 import { MIMES } from './consts'
@@ -32,6 +33,10 @@ export function sendRedirect (event: CompatibilityEvent, location: string, code 
   <body>Redirecting to <a href=${JSON.stringify(location)}>${encodeURI(location)}</a></body>
 </html>`
   return send(event, html, MIMES.html)
+}
+
+export function setHeader (event: CompatibilityEvent, name: string, value: Parameters<OutgoingMessage['setHeader']>[1]): void {
+  event.res.setHeader(name, value)
 }
 
 export function appendHeader (event: CompatibilityEvent, name: string, value: string): void {

--- a/src/utils/response.ts
+++ b/src/utils/response.ts
@@ -35,11 +35,33 @@ export function sendRedirect (event: CompatibilityEvent, location: string, code 
   return send(event, html, MIMES.html)
 }
 
-export function setHeader (event: CompatibilityEvent, name: string, value: Parameters<OutgoingMessage['setHeader']>[1]): void {
+export function getResponseHeaders (event: CompatibilityEvent): ReturnType<CompatibilityEvent['res']['getHeaders']> {
+  return event.res.getHeaders()
+}
+
+export function getResponseHeader (event: CompatibilityEvent, name: string): ReturnType<CompatibilityEvent['res']['getHeader']> {
+  return event.res.getHeader(name)
+}
+
+export function setResponseHeaders (event: CompatibilityEvent, headers: Record<string, Parameters<OutgoingMessage['setHeader']>[1]>): void {
+  Object.entries(headers).forEach(([name, value]) => event.res.setHeader(name, value))
+}
+
+export const setHeaders = setResponseHeaders
+
+export function setResponseHeader (event: CompatibilityEvent, name: string, value: Parameters<OutgoingMessage['setHeader']>[1]): void {
   event.res.setHeader(name, value)
 }
 
-export function appendHeader (event: CompatibilityEvent, name: string, value: string): void {
+export const setHeader = setResponseHeader
+
+export function appendResponseHeaders (event: CompatibilityEvent, headers: Record<string, string>): void {
+  Object.entries(headers).forEach(([name, value]) => appendResponseHeader(event, name, value))
+}
+
+export const appendHeaders = appendResponseHeaders
+
+export function appendResponseHeader (event: CompatibilityEvent, name: string, value: string): void {
   let current = event.res.getHeader(name)
 
   if (!current) {
@@ -53,6 +75,8 @@ export function appendHeader (event: CompatibilityEvent, name: string, value: st
 
   event.res.setHeader(name, current.concat(value))
 }
+
+export const appendHeader = appendResponseHeader
 
 export function isStream (data: any) {
   return data && typeof data === 'object' && typeof data.pipe === 'function' && typeof data.on === 'function'

--- a/test/header.test.ts
+++ b/test/header.test.ts
@@ -1,6 +1,21 @@
 import supertest, { SuperTest, Test } from 'supertest'
 import { describe, it, expect, beforeEach } from 'vitest'
-import { createApp, App, getHeaders, getHeader, setHeader, appendHeader } from '../src'
+import {
+  createApp,
+  App,
+  getRequestHeaders,
+  getHeaders,
+  getRequestHeader,
+  getHeader,
+  setResponseHeaders,
+  setHeaders,
+  setResponseHeader,
+  setHeader,
+  appendResponseHeaders,
+  appendHeaders,
+  appendResponseHeader,
+  appendHeader
+} from '../src'
 
 describe('', () => {
   let app: App
@@ -9,6 +24,16 @@ describe('', () => {
   beforeEach(() => {
     app = createApp({ debug: false })
     request = supertest(app)
+  })
+
+  describe('getRequestHeaders', () => {
+    it('can return request headers', async () => {
+      app.use('/', (request) => {
+        const headers = getRequestHeaders(request)
+        expect(headers).toEqual(request.headers)
+      })
+      await request.get('/').set('Accept', 'application/json')
+    })
   })
 
   describe('getHeaders', () => {
@@ -21,6 +46,16 @@ describe('', () => {
     })
   })
 
+  describe('getRequestHeader', () => {
+    it('can return a value of request header corresponding to the given name', async () => {
+      app.use('/', (request) => {
+        expect(getRequestHeader(request, 'accept')).toEqual('application/json')
+        expect(getRequestHeader(request, 'Accept')).toEqual('application/json')
+      })
+      await request.get('/').set('Accept', 'application/json')
+    })
+  })
+
   describe('getHeader', () => {
     it('can return a value of request header corresponding to the given name', async () => {
       app.use('/', (request) => {
@@ -28,6 +63,55 @@ describe('', () => {
         expect(getHeader(request, 'Accept')).toEqual('application/json')
       })
       await request.get('/').set('Accept', 'application/json')
+    })
+  })
+
+  describe('setResponseHeaders', () => {
+    it('can set multiple values to multiple response headers corresponding to the given object', async () => {
+      app.use('/', (request) => {
+        setResponseHeaders(request, { 'Nuxt-HTTP-Header-1': 'string-value-1', 'Nuxt-HTTP-Header-2': 'string-value-2' })
+      })
+      const result = await request.get('/')
+      expect(result.headers['nuxt-http-header-1']).toEqual('string-value-1')
+      expect(result.headers['nuxt-http-header-2']).toEqual('string-value-2')
+    })
+  })
+
+  describe('setHeaders', () => {
+    it('can set multiple values to multiple response headers corresponding to the given object', async () => {
+      app.use('/', (request) => {
+        setHeaders(request, { 'Nuxt-HTTP-Header-1': 'string-value-1', 'Nuxt-HTTP-Header-2': 'string-value-2' })
+      })
+      const result = await request.get('/')
+      expect(result.headers['nuxt-http-header-1']).toEqual('string-value-1')
+      expect(result.headers['nuxt-http-header-2']).toEqual('string-value-2')
+    })
+  })
+
+  describe('setResponseHeader', () => {
+    it('can set a string value to response header corresponding to the given name', async () => {
+      app.use('/', (request) => {
+        setResponseHeader(request, 'Nuxt-HTTP-Header', 'string-value')
+      })
+      const result = await request.get('/')
+      expect(result.headers['nuxt-http-header']).toEqual('string-value')
+    })
+
+    it('can set a number value to response header corresponding to the given name', async () => {
+      app.use('/', (request) => {
+        setResponseHeader(request, 'Nuxt-HTTP-Header', 12345)
+      })
+      const result = await request.get('/')
+      expect(result.headers['nuxt-http-header']).toEqual('12345')
+    })
+
+    it('can set an array value to response header corresponding to the given name', async () => {
+      app.use('/', (request) => {
+        setResponseHeader(request, 'Nuxt-HTTP-Header', ['value 1', 'value 2'])
+        setResponseHeader(request, 'Nuxt-HTTP-Header', ['value 3', 'value 4'])
+      })
+      const result = await request.get('/')
+      expect(result.headers['nuxt-http-header']).toEqual('value 3, value 4')
     })
   })
 
@@ -55,6 +139,41 @@ describe('', () => {
       })
       const result = await request.get('/')
       expect(result.headers['nuxt-http-header']).toEqual('value 3, value 4')
+    })
+  })
+
+  describe('appendResponseHeaders', () => {
+    it('can append multiple string values to multiple response header corresponding to the given object', async () => {
+      app.use('/', (request) => {
+        appendResponseHeaders(request, { 'Nuxt-HTTP-Header-1': 'string-value-1-1', 'Nuxt-HTTP-Header-2': 'string-value-2-1' })
+        appendResponseHeaders(request, { 'Nuxt-HTTP-Header-1': 'string-value-1-2', 'Nuxt-HTTP-Header-2': 'string-value-2-2' })
+      })
+      const result = await request.get('/')
+      expect(result.headers['nuxt-http-header-1']).toEqual('string-value-1-1, string-value-1-2')
+      expect(result.headers['nuxt-http-header-2']).toEqual('string-value-2-1, string-value-2-2')
+    })
+  })
+
+  describe('appendHeaders', () => {
+    it('can append multiple string values to multiple response header corresponding to the given object', async () => {
+      app.use('/', (request) => {
+        appendHeaders(request, { 'Nuxt-HTTP-Header-1': 'string-value-1-1', 'Nuxt-HTTP-Header-2': 'string-value-2-1' })
+        appendHeaders(request, { 'Nuxt-HTTP-Header-1': 'string-value-1-2', 'Nuxt-HTTP-Header-2': 'string-value-2-2' })
+      })
+      const result = await request.get('/')
+      expect(result.headers['nuxt-http-header-1']).toEqual('string-value-1-1, string-value-1-2')
+      expect(result.headers['nuxt-http-header-2']).toEqual('string-value-2-1, string-value-2-2')
+    })
+  })
+
+  describe('appendResponseHeader', () => {
+    it('can append a value to response header corresponding to the given name', async () => {
+      app.use('/', (request) => {
+        appendResponseHeader(request, 'Nuxt-HTTP-Header', 'value 1')
+        appendResponseHeader(request, 'Nuxt-HTTP-Header', 'value 2')
+      })
+      const result = await request.get('/')
+      expect(result.headers['nuxt-http-header']).toEqual('value 1, value 2')
     })
   })
 

--- a/test/header.test.ts
+++ b/test/header.test.ts
@@ -1,0 +1,71 @@
+import supertest, { SuperTest, Test } from 'supertest'
+import { describe, it, expect, beforeEach } from 'vitest'
+import { createApp, App, getHeaders, getHeader, setHeader, appendHeader } from '../src'
+
+describe('', () => {
+  let app: App
+  let request: SuperTest<Test>
+
+  beforeEach(() => {
+    app = createApp({ debug: false })
+    request = supertest(app)
+  })
+
+  describe('getHeaders', () => {
+    it('can return request headers', async () => {
+      app.use('/', (request) => {
+        const headers = getHeaders(request)
+        expect(headers).toEqual(request.headers)
+      })
+      await request.get('/').set('Accept', 'application/json')
+    })
+  })
+
+  describe('getHeader', () => {
+    it('can return a value of request header corresponding to the given name', async () => {
+      app.use('/', (request) => {
+        expect(getHeader(request, 'accept')).toEqual('application/json')
+        expect(getHeader(request, 'Accept')).toEqual('application/json')
+      })
+      await request.get('/').set('Accept', 'application/json')
+    })
+  })
+
+  describe('setHeader', () => {
+    it('can set a string value to response header corresponding to the given name', async () => {
+      app.use('/', (request) => {
+        setHeader(request, 'Nuxt-HTTP-Header', 'string-value')
+      })
+      const result = await request.get('/')
+      expect(result.headers['nuxt-http-header']).toEqual('string-value')
+    })
+
+    it('can set a number value to response header corresponding to the given name', async () => {
+      app.use('/', (request) => {
+        setHeader(request, 'Nuxt-HTTP-Header', 12345)
+      })
+      const result = await request.get('/')
+      expect(result.headers['nuxt-http-header']).toEqual('12345')
+    })
+
+    it('can set an array value to response header corresponding to the given name', async () => {
+      app.use('/', (request) => {
+        setHeader(request, 'Nuxt-HTTP-Header', ['value 1', 'value 2'])
+        setHeader(request, 'Nuxt-HTTP-Header', ['value 3', 'value 4'])
+      })
+      const result = await request.get('/')
+      expect(result.headers['nuxt-http-header']).toEqual('value 3, value 4')
+    })
+  })
+
+  describe('appendHeader', () => {
+    it('can append a value to response header corresponding to the given name', async () => {
+      app.use('/', (request) => {
+        appendHeader(request, 'Nuxt-HTTP-Header', 'value 1')
+        appendHeader(request, 'Nuxt-HTTP-Header', 'value 2')
+      })
+      const result = await request.get('/')
+      expect(result.headers['nuxt-http-header']).toEqual('value 1, value 2')
+    })
+  })
+})


### PR DESCRIPTION
resolves #147

I added the following 3 utility functions as @pi0 suggested:

- `getHeaders(event)` for request
- `getHeader(event, name)` for request
- `setHeader(event, name, value)`

In addition, I added a unit test for `appendHeader()` function.

---

Do we need to make `getHeaders` and `getHeader` available for response?

For your reference, Express.js provides such functions as methods on `req` and `res` objects (i.e. `req.get` and `res.get`), so it's obvious from what object the functions get headers.

There are 2 ways to provide same functionalities with normal functions.

One is to let users pass `event.req` or `event.res`:

- `getHeaders(event.req)` / `getHeader(event.req, name)`
- `getHeaders(event.res)` / `getHeader(event.res, name)`

But `event` may be an `IncomingMessage` so developers must know which to pass to the function.

- `getHeaders(event)` (event is an `IncomingMessage`)

Another way is to provide functions dedicated to `req` and `res`:

- `getReqHeaders(event)` / `getReqHeader(event, name)`
- `getResHeaders(event)` / `getResHeader(event, name)`