### PR TITLE
feat: add utility for router params (#120)

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Instead of adding helpers to `req` and `res`, h3 exposes them as composable util
 - `setCookie(res, name, value, opts?)`
 - `deleteCookie(res, name, opts?)`
 - `useQuery(req)`
+- `getRouterParams(event)`
 - `send(res, data, type?)`
 - `sendRedirect(res, location, code=302)`
 - `getRequestHeaders(event, headers)` (alias: `getHeaders`)

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -10,6 +10,14 @@ export function getQuery (event: CompatibilityEvent) {
 /** @deprecated Use `h3.getQuery` */
 export const useQuery = getQuery
 
+export function getRouterParams (event: CompatibilityEvent): CompatibilityEvent['context'] {
+  // Fallback object needs to be returned in case router is not used (#149)
+  return event.context.params || {}
+}
+
+/** @deprecated Use `h3.getRouterParams` */
+export const useRouterParams = getRouterParams
+
 export function getMethod (event: CompatibilityEvent, defaultMethod: HTTPMethod = 'GET'): HTTPMethod {
   return (event.req.method || defaultMethod).toUpperCase() as HTTPMethod
 }

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -18,6 +18,15 @@ export function getRouterParams (event: CompatibilityEvent): CompatibilityEvent[
 /** @deprecated Use `h3.getRouterParams` */
 export const useRouterParams = getRouterParams
 
+export function getRouterParam (event: CompatibilityEvent, name: string): CompatibilityEvent['context'][string] {
+  const params = getRouterParams(event)
+
+  return params[name]
+}
+
+/** @deprecated Use `h3.getRouterParam` */
+export const useRouterParam = getRouterParam
+
 export function getMethod (event: CompatibilityEvent, defaultMethod: HTTPMethod = 'GET'): HTTPMethod {
   return (event.req.method || defaultMethod).toUpperCase() as HTTPMethod
 }

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -15,17 +15,11 @@ export function getRouterParams (event: CompatibilityEvent): CompatibilityEvent[
   return event.context.params || {}
 }
 
-/** @deprecated Use `h3.getRouterParams` */
-export const useRouterParams = getRouterParams
-
 export function getRouterParam (event: CompatibilityEvent, name: string): CompatibilityEvent['context'][string] {
   const params = getRouterParams(event)
 
   return params[name]
 }
-
-/** @deprecated Use `h3.getRouterParam` */
-export const useRouterParam = getRouterParam
 
 export function getMethod (event: CompatibilityEvent, defaultMethod: HTTPMethod = 'GET'): HTTPMethod {
   return (event.req.method || defaultMethod).toUpperCase() as HTTPMethod

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -1,6 +1,6 @@
 import supertest, { SuperTest, Test } from 'supertest'
 import { describe, it, expect, beforeEach } from 'vitest'
-import { createApp, createRouter, App, Router, getRouterParams, useRouterParams, getRouterParam, useRouterParam } from '../src'
+import { createApp, createRouter, App, Router, getRouterParams, getRouterParam } from '../src'
 
 describe('router', () => {
   let app: App
@@ -62,7 +62,7 @@ describe('router', () => {
   })
 })
 
-describe('getRouterParams / useRouterParams', () => {
+describe('getRouterParams', () => {
   let app: App
   let request: SuperTest<Test>
 
@@ -75,7 +75,6 @@ describe('getRouterParams / useRouterParams', () => {
     it('can return router params', async () => {
       const router = createRouter().get('/test/params/:name', (request) => {
         expect(getRouterParams(request)).toMatchObject({ name: 'string' })
-        expect(useRouterParams(request)).toMatchObject({ name: 'string' })
         return '200'
       })
       app.use(router)
@@ -89,7 +88,6 @@ describe('getRouterParams / useRouterParams', () => {
     it('can return an empty object if router is not used', async () => {
       app.use('/', (request) => {
         expect(getRouterParams(request)).toMatchObject({})
-        expect(useRouterParams(request)).toMatchObject({})
         return '200'
       })
       const result = await request.get('/test/empty/params')
@@ -99,7 +97,7 @@ describe('getRouterParams / useRouterParams', () => {
   })
 })
 
-describe('getRouterParam / useRouterParam', () => {
+describe('getRouterParam', () => {
   let app: App
   let request: SuperTest<Test>
 
@@ -112,7 +110,6 @@ describe('getRouterParam / useRouterParam', () => {
     it('can return a value of router params corresponding to the given name', async () => {
       const router = createRouter().get('/test/params/:name', (request) => {
         expect(getRouterParam(request, 'name')).toEqual('string')
-        expect(useRouterParam(request, 'name')).toEqual('string')
         return '200'
       })
       app.use(router)
@@ -126,7 +123,6 @@ describe('getRouterParam / useRouterParam', () => {
     it('can return `undefined` for any keys', async () => {
       app.use('/', (request) => {
         expect(getRouterParam(request, 'name')).toEqual(undefined)
-        expect(useRouterParam(request, 'name')).toEqual(undefined)
         return '200'
       })
       const result = await request.get('/test/empty/params')

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,6 +1,6 @@
 import supertest, { SuperTest, Test } from 'supertest'
 import { describe, it, expect, beforeEach } from 'vitest'
-import { createApp, App, sendRedirect, useBase, useQuery, useMethod, assertMethod } from '../src'
+import { createApp, createRouter, App, sendRedirect, useBase, useQuery, getRouterParams, useRouterParams, useMethod, assertMethod } from '../src'
 
 describe('', () => {
   let app: App
@@ -48,6 +48,56 @@ describe('', () => {
         return '200'
       })
       const result = await request.get('/api/test?bool=true&name=string&number=1')
+
+      expect(result.text).toBe('200')
+    })
+  })
+
+  describe('getRouterParams', () => {
+    it('can return router params', async () => {
+      const router = createRouter().get('/api/test/:name', (request) => {
+        const params = getRouterParams(request)
+        expect(params).toMatchObject({ name: 'string' })
+        return '200'
+      })
+      app.use(router)
+      const result = await request.get('/api/test/string')
+
+      expect(result.text).toBe('200')
+    })
+
+    it('can return an empty object if router is not used', async () => {
+      app.use('/', (request) => {
+        const params = getRouterParams(request)
+        expect(params).toMatchObject({})
+        return '200'
+      })
+      const result = await request.get('/')
+
+      expect(result.text).toBe('200')
+    })
+  })
+
+  describe('useRouterParams', () => {
+    it('can return router params', async () => {
+      const router = createRouter().get('/api/test/:name', (request) => {
+        const query = useRouterParams(request)
+        expect(query).toMatchObject({ name: 'string' })
+        return '200'
+      })
+      app.use(router)
+      const result = await request.get('/api/test/string')
+
+      expect(result.text).toBe('200')
+    })
+
+    it('can return an empty object if router is not used', async () => {
+      app.use('/', (request) => {
+        const params = useRouterParams(request)
+        expect(params).toMatchObject({})
+        return '200'
+      })
+      const result = await request.get('/')
 
       expect(result.text).toBe('200')
     })

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,6 +1,6 @@
 import supertest, { SuperTest, Test } from 'supertest'
 import { describe, it, expect, beforeEach } from 'vitest'
-import { createApp, createRouter, App, sendRedirect, useBase, useQuery, getRouterParams, useRouterParams, useMethod, assertMethod } from '../src'
+import { createApp, App, sendRedirect, useBase, useQuery, useMethod, assertMethod } from '../src'
 
 describe('', () => {
   let app: App
@@ -48,56 +48,6 @@ describe('', () => {
         return '200'
       })
       const result = await request.get('/api/test?bool=true&name=string&number=1')
-
-      expect(result.text).toBe('200')
-    })
-  })
-
-  describe('getRouterParams', () => {
-    it('can return router params', async () => {
-      const router = createRouter().get('/api/test/:name', (request) => {
-        const params = getRouterParams(request)
-        expect(params).toMatchObject({ name: 'string' })
-        return '200'
-      })
-      app.use(router)
-      const result = await request.get('/api/test/string')
-
-      expect(result.text).toBe('200')
-    })
-
-    it('can return an empty object if router is not used', async () => {
-      app.use('/', (request) => {
-        const params = getRouterParams(request)
-        expect(params).toMatchObject({})
-        return '200'
-      })
-      const result = await request.get('/')
-
-      expect(result.text).toBe('200')
-    })
-  })
-
-  describe('useRouterParams', () => {
-    it('can return router params', async () => {
-      const router = createRouter().get('/api/test/:name', (request) => {
-        const query = useRouterParams(request)
-        expect(query).toMatchObject({ name: 'string' })
-        return '200'
-      })
-      app.use(router)
-      const result = await request.get('/api/test/string')
-
-      expect(result.text).toBe('200')
-    })
-
-    it('can return an empty object if router is not used', async () => {
-      app.use('/', (request) => {
-        const params = useRouterParams(request)
-        expect(params).toMatchObject({})
-        return '200'
-      })
-      const result = await request.get('/')
 
       expect(result.text).toBe('200')
     })


### PR DESCRIPTION
Resolves #120 

I added `getRouterParams(event)` utility function.
I also added `useRouterParams(event)` for it to be aligned with other API until the next braking change (may be v1?).