### PR TITLE
fix: preserve original error stack

### DIFF
--- a/src/error.ts
+++ b/src/error.ts
@@ -40,6 +40,7 @@ export function createError (input: string | Partial<H3Error>): H3Error {
   const err = new H3Error(input.message ?? input.statusMessage, input.cause ? { cause: input.cause } : undefined)
 
   if (input.statusCode) { err.statusCode = input.statusCode }
+  if (input.stack) { err.stack = input.stack }
   if (input.statusMessage) { err.statusMessage = input.statusMessage }
   if (input.data) { err.data = input.data }
   if (input.fatal !== undefined) { err.fatal = input.fatal }


### PR DESCRIPTION
Currently errors logged by h3 always point to h3 itself rather than the source of the error, e.g.:

```
[h3] [unhandled] H3Error: window is not defined
    at createError (file:///private/tmp/vueqr/node_modules/.pnpm/h3@0.7.14/node_modules/h3/dist/index.mjs:238:15)
    at Server.nodeHandler (file:///private/tmp/vueqr/node_modules/.pnpm/h3@0.7.14/node_modules/h3/dist/index.mjs:431:21) {
  statusCode: 500,
  fatal: false,
  unhandled: true,
  statusMessage: 'Internal Server Error'
}
[nuxt] [request error] window is not defined
  at createError (./node_modules/.pnpm/h3@0.7.14/node_modules/h3/dist/index.mjs:238:15)  
  at Server.nodeHandler (./node_modules/.pnpm/h3@0.7.14/node_modules/h3/dist/index.mjs:431:21)
```

This PR changes it to the original stack trace:

```
[h3] [unhandled] ReferenceError: window is not defined
    at $id_aX1WMBYGcH (file:///private/tmp/vueqr/.nuxt/dist/server/server.mjs:4520:5)
    at async __instantiateModule__ (file:///private/tmp/vueqr/.nuxt/dist/server/server.mjs:8426:3) {
  statusCode: 500,
  fatal: false,
  unhandled: true,
  statusMessage: 'Internal Server Error'
}
[nuxt] [request error] window is not defined
  at $id_aX1WMBYGcH (./.nuxt/dist/server/server.mjs:4520:5)  
  at async __instantiateModule__ (./.nuxt/dist/server/server.mjs:8426:3)
```