### PR TITLE
fix: don not log errors when `onError` is provided

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -64,13 +64,12 @@ export function createApp (options: AppOptions = {}): App {
         error.unhandled = true
       }
 
-      if (error.unhandled || error.fatal) {
-        console.error('[h3]', error.fatal ? '[fatal]' : '[unhandled]', error) // eslint-disable-line no-console
-      }
-
       if (options.onError) {
         await options.onError(error, event)
       } else {
+        if (error.unhandled || error.fatal) {
+          console.error('[h3]', error.fatal ? '[fatal]' : '[unhandled]', error) // eslint-disable-line no-console
+        }
         await sendError(event, error, !!options.debug)
       }
     }


### PR DESCRIPTION
Currently we get two copies of error logs if we are logging them in a user-provided `onError` handler. Presumably it makes sense for user to log (or not) if they are providing their own error handler