### PR TITLE
fix: `context` type for `CompatibilityRequestProps`

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,9 +1,9 @@
 import type http from 'http'
-import type { H3Event } from './event'
+import type { H3Event, H3EventContext } from './event'
 
 interface CompatibilityRequestProps {
   event: H3Event
-  context: Record<string, any>
+  context: H3EventContext
   /** Only available with connect and press */
   originalUrl?: string
 }


### PR DESCRIPTION
The changes in PR #124 to make the `H3EventContext` extendable by userland types were insufficient to apply the type also to the `CompatibilityEvent`, which is the type of events for event handlers. I always got `context.user: any` when only declaring the context interface:

```ts
declare module 'h3' {
	interface H3EventContext {
		user: User,
	}
}
```

Because `CompatibilityEvent` can also be an `IncomingMessage`, which extends the `CompatibilityRequestProps`, which in turn still declares an un-extendable `context: Record<string, any>`. This gives `CompatibilityEvent.context: H3EventContext | Record<string, any>`, which gives `any` for all properties, even if `H3EventContext` is typed.