### PR TITLE
fix: use named type imports from `http`

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,4 +1,4 @@
-import type http from 'http'
+import type { IncomingMessage as NodeIncomingMessage, ServerResponse as NodeServerResponse } from 'http'
 import { withoutTrailingSlash } from 'ufo'
 import { lazyEventHandler, toEventHandler, createEvent, isEventHandler, eventHandler } from './event'
 import { createError, sendError, isError } from './error'
@@ -37,12 +37,12 @@ export type InputStack = InputLayer[]
 export type Matcher = (url: string, event?: CompatibilityEvent) => boolean
 
 export interface AppUse {
-  (route: string | string [], handler: CompatibilityEventHandler | CompatibilityEventHandler[], options?: Partial<InputLayer>): App
+  (route: string | string[], handler: CompatibilityEventHandler | CompatibilityEventHandler[], options?: Partial<InputLayer>): App
   (handler: CompatibilityEventHandler | CompatibilityEventHandler[], options?: Partial<InputLayer>): App
   (options: InputLayer): App
 }
 
-export type NodeHandler = (req: http.IncomingMessage, res: http.ServerResponse) => Promise<void>
+export type NodeHandler = (req: NodeIncomingMessage, res: NodeServerResponse) => Promise<void>
 
 export interface App extends NodeHandler {
   stack: Stack

--- a/src/event/event.ts
+++ b/src/event/event.ts
@@ -1,4 +1,4 @@
-import type http from 'http'
+import type { IncomingMessage as NodeIncomingMessage, ServerResponse as NodeServerResponse } from 'http'
 import type { IncomingMessage, ServerResponse, H3EventContext } from '../types'
 import { MIMES } from '../utils'
 import { H3Response } from './response'
@@ -10,7 +10,7 @@ export class H3Event implements Pick<FetchEvent, 'respondWith'> {
   event: H3Event
   context: H3EventContext = {}
 
-  constructor (req: http.IncomingMessage | IncomingMessage, res: http.ServerResponse | ServerResponse) {
+  constructor (req: NodeIncomingMessage | IncomingMessage, res: NodeServerResponse | ServerResponse) {
     this.req = req as IncomingMessage
     this.res = res as ServerResponse
 
@@ -74,6 +74,6 @@ export function isEvent (input: any): input is H3Event {
   return '__is_event__' in input
 }
 
-export function createEvent (req: http.IncomingMessage, res: http.ServerResponse): H3Event {
+export function createEvent (req: NodeIncomingMessage, res: NodeServerResponse): H3Event {
   return new H3Event(req, res)
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import type http from 'http'
+import type { IncomingMessage as NodeIncomingMessage, ServerResponse as NodeServerResponse } from 'http'
 import type { H3Event } from './event'
 
 interface CompatibilityRequestProps {
@@ -8,17 +8,17 @@ interface CompatibilityRequestProps {
   originalUrl?: string
 }
 
-export interface IncomingMessage extends http.IncomingMessage, CompatibilityRequestProps {
+export interface IncomingMessage extends NodeIncomingMessage, CompatibilityRequestProps {
   req: H3Event['req'],
   res: H3Event['res']
 }
-export interface ServerResponse extends http.ServerResponse{
+export interface ServerResponse extends NodeServerResponse {
   event: H3Event,
   res: H3Event['res']
-  req: http.ServerResponse['req'] & CompatibilityRequestProps
+  req: NodeServerResponse['req'] & CompatibilityRequestProps
 }
 
-export type Handler<T = any, ReqT={}> = (req: IncomingMessage & ReqT, res: ServerResponse) => T
+export type Handler<T = any, ReqT = {}> = (req: IncomingMessage & ReqT, res: ServerResponse) => T
 export type PromisifiedHandler = Handler<Promise<any>>
 export type Middleware = (req: IncomingMessage, res: ServerResponse, next: (err?: Error) => any) => any
 export type LazyHandler = () => Handler | Promise<Handler>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,6 @@
     "target": "ESNext",
     "module": "ESNext",
     "moduleResolution": "Node",
-    "esModuleInterop": true,
     "lib": [
       "WebWorker"
     ],


### PR DESCRIPTION
resolves #169

**Note**: By disabling `esModuleInterop`, we will now get the same errors as others do who are using this library without it enabled.