### PR TITLE
fix(readBody, readRawBody): use global symbol

### DIFF
--- a/src/utils/body.ts
+++ b/src/utils/body.ts
@@ -2,8 +2,8 @@ import destr from 'destr'
 import type { Encoding, HTTPMethod, CompatibilityEvent } from '../types'
 import { assertMethod } from './request'
 
-const RawBodySymbol = Symbol('h3RawBody')
-const ParsedBodySymbol = Symbol('h3RawBody')
+const RawBodySymbol = Symbol.for('h3RawBody')
+const ParsedBodySymbol = Symbol.for('h3ParsedBody')
 
 const PayloadMethods: HTTPMethod[] = ['PATCH', 'POST', 'PUT', 'DELETE']
 


### PR DESCRIPTION
This addresses the issues of #170 where a second read from the body in a different library causes the request to hang.

Changing this to use `Symbol.for()` will first check the global registry for the symbol before generating a new one. I assume this means that different registries will share the same Symbol for the body and correctly early out once processed.