### PR TITLE
chore: update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 ✔️ &nbsp;**Compatible:** Support connect/express middleware
 
-✔️ &nbsp;**Minimal:** Small, tree-shakable and zero-dependency
+✔️ &nbsp;**Minimal:** Small and tree-shakable
 
 ✔️ &nbsp;**Modern:** Native promise support
 


### PR DESCRIPTION
As shown in https://github.com/unjs/h3/blob/main/package.json#L30-L34, `h3` has dependencies, even if they are just a few. Thus, I'd remove the "zero-dependency" claim from the README ☺️ 