### PR TITLE
fix(router): make router handler non preemtive by default

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -114,7 +114,10 @@ export function createAppEventHandler (stack: Stack, options: AppOptions) {
       }
     }
     if (!event.res.writableEnded) {
-      throw createError({ statusCode: 404, statusMessage: 'Not Found' })
+      throw createError({
+        statusCode: 404,
+        statusMessage: `Cannot find any route matching ${event.req.url || '/'}.`
+      })
     }
   })
 }

--- a/src/router.ts
+++ b/src/router.ts
@@ -19,7 +19,11 @@ interface RouteNode {
   handlers: Partial<Record<RouterMethod | 'all', EventHandler>>
 }
 
-export function createRouter (): Router {
+export interface CreateRouterOptions {
+  preemtive: boolean
+}
+
+export function createRouter (opts: CreateRouterOptions = {}): Router {
   const _router = _createRouter<RouteNode>({})
   const routes: Record<string, RouteNode> = {}
 
@@ -57,13 +61,16 @@ export function createRouter (): Router {
     }
 
     const matched = _router.lookup(path)
-
     if (!matched) {
-      throw createError({
-        statusCode: 404,
-        name: 'Not Found',
-        statusMessage: `Cannot find any route matching ${event.req.url || '/'}.`
-      })
+      if (opts.preemtive) {
+        throw createError({
+          statusCode: 404,
+          name: 'Not Found',
+          statusMessage: `Cannot find any route matching ${event.req.url || '/'}.`
+        })
+      } else {
+        return // Let app match other middleware or routers
+      }
     }
 
     // Match method

--- a/src/router.ts
+++ b/src/router.ts
@@ -20,7 +20,7 @@ interface RouteNode {
 }
 
 export interface CreateRouterOptions {
-  preemtive: boolean
+  preemtive?: boolean
 }
 
 export function createRouter (opts: CreateRouterOptions = {}): Router {

--- a/src/router.ts
+++ b/src/router.ts
@@ -69,7 +69,7 @@ export function createRouter (opts: CreateRouterOptions = {}): Router {
           statusMessage: `Cannot find any route matching ${event.req.url || '/'}.`
         })
       } else {
-        return // Let app match other middleware or routers
+        return // Let app match other handlers
       }
     }
 

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -25,6 +25,19 @@ describe('router', () => {
     expect(res.text).toEqual('Hello')
   })
 
+  it('Multiple Routers', async () => {
+    const secondRouter = createRouter()
+      .add('/router2', eventHandler(() => 'router2'))
+
+    app.use(secondRouter)
+
+    const res1 = await request.get('/')
+    expect(res1.text).toEqual('Hello')
+
+    const res2 = await request.get('/router2')
+    expect(res2.text).toEqual('router2')
+  })
+
   it('Handle different methods', async () => {
     const res1 = await request.get('/test')
     expect(res1.text).toEqual('Test (GET)')


### PR DESCRIPTION
Resolves #183

Make router created by `createRouter` a middleware by default. Meaning it will lt the app continue searching for other matching middleware registered after if not route matches. (if route matches but not method, it will still throw an error).

**BREAKING CHANGE:** Router middleware will not stop with 404 if no matches are found. Using new `createRouter({ preemptive: true })` previous behavior can be done to stop app middleware immediately.