### PR TITLE
fix!: remove default `statusMessage` from errors

### DIFF
--- a/playground/index.ts
+++ b/playground/index.ts
@@ -1,9 +1,12 @@
 import { listen } from 'listhen'
-import { createApp, createRouter, eventHandler, toNodeListener, parseCookies } from '../src'
+import { createApp, createRouter, eventHandler, toNodeListener, parseCookies, createError } from '../src'
 
 const app = createApp({ debug: true })
 const router = createRouter()
   .get('/', eventHandler(() => 'Hello World!'))
+  .get('/error/:code', eventHandler((event) => {
+    throw createError({ statusCode: parseInt(event.context.params.code) })
+  }))
   .get('/hello/:name', eventHandler((event) => {
     return `Hello ${parseCookies(event)}!`
   }))

--- a/src/error.ts
+++ b/src/error.ts
@@ -18,7 +18,7 @@ export class H3Error extends Error {
   statusCode: number = 500
   fatal: boolean = false
   unhandled: boolean = false
-  statusMessage: string = 'Internal Server Error'
+  statusMessage?: string = undefined
   data?: any
 }
 
@@ -84,8 +84,13 @@ export function sendError (event: H3Event, error: Error | H3Error, debug?: boole
   }
 
   if (event.res.writableEnded) { return }
-  event.res.statusCode = h3Error.statusCode
-  event.res.statusMessage = h3Error.statusMessage
+  const _code = parseInt(h3Error.statusCode as unknown as string)
+  if (_code) {
+    event.res.statusCode = _code
+  }
+  if (h3Error.statusMessage) {
+    event.res.statusMessage = h3Error.statusMessage
+  }
   event.res.setHeader('Content-Type', MIMES.json)
   event.res.end(JSON.stringify(responseBody, null, 2))
 }

--- a/test/error.test.ts
+++ b/test/error.test.ts
@@ -39,8 +39,7 @@ describe('error', () => {
 
     expect(result.status).toBe(500)
     expect(JSON.parse(result.text)).toMatchObject({
-      statusCode: 500,
-      statusMessage: 'Internal Server Error'
+      statusCode: 500
     })
   })
 


### PR DESCRIPTION
Resolves #187

As suggested by @maicss, HTTP agents and servers (edge, browser, curl, etc) already resolve to the correct corresponding message for each error code. We don't need to bundle a preset of them or add a rather misleading "Internal Server Error" to all thrown errors.