### PR TITLE
fix(router): parse url using `URL` for pathname

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -47,17 +47,11 @@ export function createRouter (): Router {
 
   // Main handle
   router.handler = eventHandler((event) => {
-    // Match route
-
     // Remove query parameters for matching
-    let path = event.req.url || '/'
-    const queryUrlIndex = path.lastIndexOf('?')
-    if (queryUrlIndex > -1) {
-      path = path.substring(0, queryUrlIndex)
-    }
+    const path = new URL(event.req.url || '/', 'http://localhost').pathname
 
+    // Match route
     const matched = _router.lookup(path)
-
     if (!matched) {
       throw createError({
         statusCode: 404,

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -37,7 +37,7 @@ describe('router', () => {
   })
 
   it('Handle url with query parameters, include "?" in url path', async () => {
-    const res = await request.get('/test/?/a?title=test')
+    const res = await request.get('/test/?/a?title=test&returnTo=/path?foo=bar')
     expect(res.status).toEqual(200)
   })
 


### PR DESCRIPTION
Resolves #190

Using `URL` to parse and and extract pathname splitting from query.