### PR TITLE
feat: useBody takes content-type header into account

### DIFF
--- a/src/utils/body.ts
+++ b/src/utils/body.ts
@@ -1,3 +1,4 @@
+import type { IncomingMessage } from 'http'
 import destr from 'destr'
 import type { Encoding, HTTPMethod } from '../types'
 import type { H3Event } from '../event'
@@ -5,6 +6,11 @@ import { assertMethod } from './request'
 
 const RawBodySymbol = Symbol.for('h3RawBody')
 const ParsedBodySymbol = Symbol.for('h3ParsedBody')
+type InternalRequest<T=any> = IncomingMessage & {
+    [RawBodySymbol]?: Promise<Buffer>
+    [ParsedBodySymbol]?: T
+    body?: string | undefined
+}
 
 const PayloadMethods: HTTPMethod[] = ['PATCH', 'POST', 'PUT', 'DELETE']
 
@@ -15,29 +21,33 @@ const PayloadMethods: HTTPMethod[] = ['PATCH', 'POST', 'PUT', 'DELETE']
  *
  * @return {String|Buffer} Encoded raw string or raw Buffer of the body
  */
-export function readRawBody (event: H3Event, encoding: Encoding = 'utf-8'): Encoding extends false ? Buffer : Promise<string | Buffer> {
+export function readRawBody (event: H3Event, encoding: false): Promise<Buffer>
+// eslint-disable-next-line no-redeclare
+export function readRawBody (event: H3Event, encoding?: Exclude<Encoding, false>): Promise<string>
+// eslint-disable-next-line no-redeclare
+export function readRawBody (event: H3Event, encoding: Encoding = 'utf-8'): Promise<Buffer | string> {
   // Ensure using correct HTTP method before attempt to read payload
   assertMethod(event, PayloadMethods)
 
-  if (RawBodySymbol in event.req) {
-    const promise = Promise.resolve((event.req as any)[RawBodySymbol])
-    return encoding ? promise.then(buff => buff.toString(encoding)) : promise
-  }
+  const request = event.req as InternalRequest
 
   // Workaround for unenv issue https://github.com/unjs/unenv/issues/8
-  if ('body' in event.req) {
-    return Promise.resolve((event.req as any).body)
+  if (request.body) {
+    return Promise.resolve(request.body)
   }
 
-  const promise = (event.req as any)[RawBodySymbol] = new Promise<Buffer>((resolve, reject) => {
-    const bodyData: any[] = []
-    event.req
-      .on('error', (err) => { reject(err) })
-      .on('data', (chunk) => { bodyData.push(chunk) })
-      .on('end', () => { resolve(Buffer.concat(bodyData)) })
-  })
+  let cachedBody = request[RawBodySymbol]
+  if (!cachedBody) {
+    cachedBody = request[RawBodySymbol] = new Promise<Buffer>((resolve, reject) => {
+      const bodyData: any[] = []
+      request
+        .on('error', (err) => { reject(err) })
+        .on('data', (chunk) => { bodyData.push(chunk) })
+        .on('end', () => { resolve(Buffer.concat(bodyData)) })
+    })
+  }
 
-  return encoding ? promise.then(buff => buff.toString(encoding)) : promise
+  return encoding ? cachedBody.then(buff => buff.toString(encoding)) : cachedBody
 }
 
 /** @deprecated Use `h3.readRawBody` */
@@ -51,25 +61,29 @@ export const useRawBody = readRawBody
  * @return {*} The `Object`, `Array`, `String`, `Number`, `Boolean`, or `null` value corresponding to the request JSON body
  *
  * ```ts
- * const body = await useBody(req)
+ * const body = await readBody(req)
  * ```
  */
-export async function readBody<T=any> (event: H3Event): Promise<T> {
-  if (ParsedBodySymbol in event.req) {
-    return (event.req as any)[ParsedBodySymbol]
+export async function readBody<T=any> (event: H3Event): Promise<T | undefined | string> {
+  const request = event.req as InternalRequest<T>
+  if (ParsedBodySymbol in request) {
+    return request[ParsedBodySymbol]
   }
 
-  // TODO: Handle buffer
-  const body = await readRawBody(event) as string
-
-  if (event.req.headers['content-type'] === 'application/x-www-form-urlencoded') {
+  const body = await readRawBody(event)
+  const contentType = request.headers['content-type']
+  if (contentType === 'application/x-www-form-urlencoded') {
     const parsedForm = Object.fromEntries(new URLSearchParams(body))
     return parsedForm as unknown as T
+  } else if (contentType === 'application/json') {
+    const json = destr(body) as T
+    request[ParsedBodySymbol] = json
+    return json
+  } else if (contentType === 'text/plain') {
+    return body as string
+  } else {
+    throw new Error(`Unsupported content-type: ${contentType}`)
   }
-
-  const json = destr(body) as T
-  (event.req as any)[ParsedBodySymbol] = json
-  return json
 }
 
 /** @deprecated Use `h3.readBody` */

--- a/test/body.test.ts
+++ b/test/body.test.ts
@@ -1,6 +1,6 @@
 import supertest, { SuperTest, Test } from 'supertest'
 import { describe, it, expect, beforeEach } from 'vitest'
-import { createApp, toNodeListener, App, useBody, useRawBody, eventHandler, readBody } from '../src'
+import { createApp, toNodeListener, App, readBody, readRawBody, eventHandler } from '../src'
 
 describe('', () => {
   let app: App
@@ -11,10 +11,10 @@ describe('', () => {
     request = supertest(toNodeListener(app))
   })
 
-  describe('useRawBody', () => {
+  describe('readRawBody', () => {
     it('can handle raw string', async () => {
       app.use('/', eventHandler(async (request) => {
-        const body = await useRawBody(request)
+        const body = await readRawBody(request)
         expect(body).toEqual('{"bool":true,"name":"string","number":1}')
         return '200'
       }))
@@ -24,6 +24,30 @@ describe('', () => {
         number: 1
       }))
 
+      expect(result.text).toBe('200')
+    })
+
+    it('returns empty string if body is not present', async () => {
+      let body
+      app.use('/', eventHandler(async (request) => {
+        body = await readRawBody(request)
+        return '200'
+      }))
+      const result = await request.post('/api/test')
+
+      expect(body).toBe('')
+      expect(result.text).toBe('200')
+    })
+
+    it('returns an empty string if body is empty', async () => {
+      let body
+      app.use('/', eventHandler(async (request) => {
+        body = await readRawBody(request)
+        return '200'
+      }))
+      const result = await request.post('/api/test').send('')
+
+      expect(body).toBe('')
       expect(result.text).toBe('200')
     })
   })
@@ -50,7 +74,7 @@ describe('', () => {
 
     it('parse the form encoded into an object', async () => {
       app.use('/', eventHandler(async (request) => {
-        const body = await useBody(request)
+        const body = await readBody(request)
         expect(body).toMatchObject({
           field: 'value',
           another: 'true',
@@ -61,6 +85,42 @@ describe('', () => {
       const result = await request.post('/api/test')
         .send('field=value&another=true&number=20')
 
+      expect(result.text).toBe('200')
+    })
+
+    it('returns empty string if body is not present with text/plain', async () => {
+      let body
+      app.use('/', eventHandler(async (request) => {
+        body = await readBody(request)
+        return '200'
+      }))
+      const result = await request.post('/api/test').set('Content-Type', 'text/plain')
+
+      expect(body).toBe('')
+      expect(result.text).toBe('200')
+    })
+
+    it('returns empty object if body is not present with json', async () => {
+      let body
+      app.use('/', eventHandler(async (request) => {
+        body = await readBody(request)
+        return '200'
+      }))
+      const result = await request.post('/api/test').set('Content-Type', 'application/json')
+
+      expect(body).toBe({})
+      expect(result.text).toBe('200')
+    })
+
+    it('returns the string if content type is plain/text', async () => {
+      let body
+      app.use('/', eventHandler(async (request) => {
+        body = await readBody(request)
+        return '200'
+      }))
+      const result = await request.post('/api/test').set('Content-Type', 'text/plain').send('{ "hello": true }')
+
+      expect(body).toBe('{ "hello": true }')
       expect(result.text).toBe('200')
     })
   })


### PR DESCRIPTION
Improves the body parsing methods in the following ways:
- readBody: only parse body as JSON if content-type indicates it is JSON
- improve internal and public typing information
- add tests, especially for empty string handling (refs https://github.com/unjs/h3/issues/197)

Depends on https://github.com/unjs/destr/pull/10.