### PR TITLE
feat(writeEarlyHints): handle object-format early hints

### DIFF
--- a/src/utils/response.ts
+++ b/src/utils/response.ts
@@ -97,6 +97,9 @@ export function writeEarlyHints (event: H3Event, hints: string | string[] | Reco
   if (typeof hints === 'string' || Array.isArray(hints)) {
     hints = { link: hints }
   }
+  hints.link = Array.isArray(hints.link) ? hints.link : hints.link.split(', ')
+  // TODO: remove when https://github.com/nodejs/node/pull/44874 is released
+  hints.link = hints.link.map(l => l.replace(/; crossorigin/g, ''))
 
   if ('writeEarlyHints' in event.res) {
     return event.res.writeEarlyHints(hints, cb)
@@ -110,10 +113,7 @@ export function writeEarlyHints (event: H3Event, hints: string | string[] | Reco
 
   let hint = 'HTTP/1.1 103 Early Hints'
   if (hints.link) {
-    const links = Array.isArray(hints.link) ? hints.link : [hints.link]
-    hint += `\r\nLink: ${links.join('\r\n')
-      // TODO: remove when https://github.com/nodejs/node/pull/44874 is released
-      .replace(/; crossorigin/g, '').split(', ')}`
+    hint += `\r\nLink: ${hints.link.join('\r\n')}`
   }
 
   for (const [header, value] of headers) {

--- a/src/utils/response.ts
+++ b/src/utils/response.ts
@@ -99,9 +99,9 @@ export function writeEarlyHints (event: H3Event, hints: string | string[] | Reco
   }
 
   if (hints.link) {
-    hints.link = Array.isArray(hints.link) ? hints.link : hints.link.split(', ')
+    hints.link = Array.isArray(hints.link) ? hints.link : hints.link.split(',')
     // TODO: remove when https://github.com/nodejs/node/pull/44874 is released
-    hints.link = hints.link.map(l => l.replace(/; crossorigin/g, ''))
+    hints.link = hints.link.map(l => l.trim().replace(/; crossorigin/g, ''))
   }
 
   if ('writeEarlyHints' in event.res) {

--- a/src/utils/response.ts
+++ b/src/utils/response.ts
@@ -110,7 +110,7 @@ export function writeEarlyHints (event: H3Event, hints: string | string[] | Reco
 
   let hint = 'HTTP/1.1 103 Early Hints'
   if (hints.link) {
-    const links = Array.isArray(hints.link) ? hints.link : Array.from(hints.link)
+    const links = Array.isArray(hints.link) ? hints.link : [hints.link]
     hint += `\r\nLink: ${links.join('\r\n')
       // TODO: remove when https://github.com/nodejs/node/pull/44874 is released
       .replace(/; crossorigin/g, '').split(', ')}`

--- a/src/utils/response.ts
+++ b/src/utils/response.ts
@@ -97,9 +97,12 @@ export function writeEarlyHints (event: H3Event, hints: string | string[] | Reco
   if (typeof hints === 'string' || Array.isArray(hints)) {
     hints = { link: hints }
   }
-  hints.link = Array.isArray(hints.link) ? hints.link : hints.link.split(', ')
-  // TODO: remove when https://github.com/nodejs/node/pull/44874 is released
-  hints.link = hints.link.map(l => l.replace(/; crossorigin/g, ''))
+
+  if (hints.link) {
+    hints.link = Array.isArray(hints.link) ? hints.link : hints.link.split(', ')
+    // TODO: remove when https://github.com/nodejs/node/pull/44874 is released
+    hints.link = hints.link.map(l => l.replace(/; crossorigin/g, ''))
+  }
 
   if ('writeEarlyHints' in event.res) {
     return event.res.writeEarlyHints(hints, cb)
@@ -113,7 +116,7 @@ export function writeEarlyHints (event: H3Event, hints: string | string[] | Reco
 
   let hint = 'HTTP/1.1 103 Early Hints'
   if (hints.link) {
-    hint += `\r\nLink: ${hints.link.join('\r\n')}`
+    hint += `\r\nLink: ${(hints.link as string[]).join('\r\n')}`
   }
 
   for (const [header, value] of headers) {

--- a/src/utils/response.ts
+++ b/src/utils/response.ts
@@ -102,7 +102,7 @@ export function writeEarlyHints (event: H3Event, hints: string | string[] | Reco
     return event.res.writeEarlyHints(hints, cb)
   }
 
-  const headers: [string, string | string[]][] = Object.entries(hints)
+  const headers: [string, string | string[]][] = Object.entries(hints).map(e => [e[0].toLowerCase(), e[1]])
   if (!headers.length) {
     cb()
     return
@@ -117,7 +117,7 @@ export function writeEarlyHints (event: H3Event, hints: string | string[] | Reco
   }
 
   for (const [header, value] of headers) {
-    if (header.toLowerCase() === 'link') { continue }
+    if (header === 'link') { continue }
     hint += `\r\n${header}: ${value}`
   }
   (event.res as ServerResponse).socket!.write(`${hint}\r\n\r\n`, 'utf-8', cb)


### PR DESCRIPTION
subsequent to previous implementation, https://github.com/nodejs/node/pull/44820 made format object-based. this pr aligns h3 with node's current implementation

before https://github.com/nodejs/node/pull/44874 is released, we also have to manually replace crossorigin attribute 🤦