### PR TITLE
chore: add more tests for empty and non-present  

### DIFF
--- a/test/body.test.ts
+++ b/test/body.test.ts
@@ -26,6 +26,42 @@ describe('', () => {
 
       expect(result.text).toBe('200')
     })
+
+    it('returns empty string if body is not present', async () => {
+      let body = 'initial'
+      app.use('/', eventHandler(async (request) => {
+        body = await readRawBody(request)
+        return '200'
+      }))
+      const result = await request.post('/api/test')
+
+      expect(body).toBeUndefined()
+      expect(result.text).toBe('200')
+    })
+
+    it('returns an empty string if body is empty', async () => {
+      let body = 'initial'
+      app.use('/', eventHandler(async (request) => {
+        body = await readRawBody(request)
+        return '200'
+      }))
+      const result = await request.post('/api/test').send('')
+
+      expect(body).toBe('')
+      expect(result.text).toBe('200')
+    })
+
+    it('returns an empty string if body is empty object', async () => {
+      let body = 'initial'
+      app.use('/', eventHandler(async (request) => {
+        body = await readRawBody(request)
+        return '200'
+      }))
+      const result = await request.post('/api/test').send({})
+
+      expect(body).toBe('')
+      expect(result.text).toBe('200')
+    })
   })
 
   describe('readBody', () => {
@@ -48,10 +84,18 @@ describe('', () => {
       expect(result.text).toBe('200')
     })
 
-    it('handles empty body', async () => {
+    it('handles non-present body', async () => {
       let _body = 'initial'
       app.use('/', eventHandler(async (request) => { _body = await readBody(request); return '200' }))
       const result = await request.post('/api/test').send()
+      expect(_body).toBeUndefined()
+      expect(result.text).toBe('200')
+    })
+
+    it('handles empty body', async () => {
+      let _body = 'initial'
+      app.use('/', eventHandler(async (request) => { _body = await readBody(request); return '200' }))
+      const result = await request.post('/api/test').send('')
       expect(_body).toBeUndefined()
       expect(result.text).toBe('200')
     })

--- a/test/body.test.ts
+++ b/test/body.test.ts
@@ -45,9 +45,9 @@ describe('', () => {
         body = await readRawBody(request) as string
         return '200'
       }))
-      const result = await request.post('/api/test').send('')
+      const result = await request.post('/api/test').send('""')
 
-      expect(body).toBe('')
+      expect(body).toBe('""')
       expect(result.text).toBe('200')
     })
 
@@ -97,8 +97,8 @@ describe('', () => {
       app.use('/', eventHandler(async (request) => {
         _body = await readBody(request); return '200'
       }))
-      const result = await request.post('/api/test').set('Content-Type', 'text/plain').send('')
-      expect(_body).toStrictEqual({})
+      const result = await request.post('/api/test').set('Content-Type', 'text/plain').send('""')
+      expect(_body).toStrictEqual('')
       expect(result.text).toBe('200')
     })
 

--- a/test/body.test.ts
+++ b/test/body.test.ts
@@ -27,10 +27,10 @@ describe('', () => {
       expect(result.text).toBe('200')
     })
 
-    it('returns empty string if body is not present', async () => {
+    it('returns undefined if body is not present', async () => {
       let body = 'initial'
       app.use('/', eventHandler(async (request) => {
-        body = await readRawBody(request)
+        body = await readRawBody(request) as string
         return '200'
       }))
       const result = await request.post('/api/test')
@@ -42,7 +42,7 @@ describe('', () => {
     it('returns an empty string if body is empty', async () => {
       let body = 'initial'
       app.use('/', eventHandler(async (request) => {
-        body = await readRawBody(request)
+        body = await readRawBody(request) as string
         return '200'
       }))
       const result = await request.post('/api/test').send('')
@@ -51,15 +51,15 @@ describe('', () => {
       expect(result.text).toBe('200')
     })
 
-    it('returns an empty string if body is empty object', async () => {
+    it('returns an empty object string if body is empty object', async () => {
       let body = 'initial'
       app.use('/', eventHandler(async (request) => {
-        body = await readRawBody(request)
+        body = await readRawBody(request) as string
         return '200'
       }))
       const result = await request.post('/api/test').send({})
 
-      expect(body).toBe('')
+      expect(body).toBe('{}')
       expect(result.text).toBe('200')
     })
   })
@@ -94,9 +94,21 @@ describe('', () => {
 
     it('handles empty body', async () => {
       let _body = 'initial'
-      app.use('/', eventHandler(async (request) => { _body = await readBody(request); return '200' }))
-      const result = await request.post('/api/test').send('')
-      expect(_body).toBeUndefined()
+      app.use('/', eventHandler(async (request) => {
+        _body = await readBody(request); return '200'
+      }))
+      const result = await request.post('/api/test').set('Content-Type', 'text/plain').send('')
+      expect(_body).toStrictEqual({})
+      expect(result.text).toBe('200')
+    })
+
+    it('handles empty object as body', async () => {
+      let _body = 'initial'
+      app.use('/', eventHandler(async (request) => {
+        _body = await readBody(request); return '200'
+      }))
+      const result = await request.post('/api/test').send({})
+      expect(_body).toStrictEqual({})
       expect(result.text).toBe('200')
     })
 


### PR DESCRIPTION
Add a few more test cases around empty and non-present bodies for https://github.com/unjs/h3/issues/197.

Some of the tests are currently failing as readBody/readBodyRaw for a request with `Content-Type: 'text/plain'` and `body: ''`  return undefined now. Is this the expected behavior? #197 was about distinguishing empty vs non-present bodies, but both return undefined now.