### PR TITLE
feat(createError): support `status` and `statusText`

### DIFF
--- a/src/error.ts
+++ b/src/error.ts
@@ -48,6 +48,8 @@ export function createError (input: string | Partial<H3Error> & { status?: numbe
     }
   }
 
+  if (input.data) { err.data = input.data }
+
   if (input.statusCode) { err.statusCode = input.statusCode } else if (input.status) { err.statusCode = input.status }
   if (input.statusMessage) { err.statusMessage = input.statusMessage } else if (input.statusText) { err.statusMessage = input.statusText }
 

--- a/src/error.ts
+++ b/src/error.ts
@@ -28,7 +28,7 @@ export class H3Error extends Error {
  * @param input {Partial<H3Error>}
  * @return {H3Error} An instance of the H3Error
  */
-export function createError (input: string | Partial<H3Error>): H3Error {
+export function createError (input: string | Partial<H3Error> & { status?: number, statusText?: string }): H3Error {
   if (typeof input === 'string') {
     return new H3Error(input)
   }
@@ -48,9 +48,9 @@ export function createError (input: string | Partial<H3Error>): H3Error {
     }
   }
 
-  if (input.statusCode) { err.statusCode = input.statusCode }
-  if (input.statusMessage) { err.statusMessage = input.statusMessage }
-  if (input.data) { err.data = input.data }
+  if (input.statusCode) { err.statusCode = input.statusCode } else if (input.status) { err.statusCode = input.status }
+  if (input.statusMessage) { err.statusMessage = input.statusMessage } else if (input.statusText) { err.statusMessage = input.statusText }
+
   if (input.fatal !== undefined) { err.fatal = input.fatal }
   if (input.unhandled !== undefined) { err.unhandled = input.unhandled }
 


### PR DESCRIPTION
Support `status` and `statusText` for [Response](https://developer.mozilla.org/en-US/docs/Web/API/Response) compatibility