### PR TITLE
docs: add missing dependency in usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ pnpm add h3
 
 ```ts
 import { createServer } from 'http'
-import { createApp, eventHandler } from 'h3'
+import { createApp, eventHandler, toNodeListener } from 'h3'
 
 const app = createApp()
 app.use('/', eventHandler(() => 'Hello world!'))


### PR DESCRIPTION
I just added `toNodeListener` to dependencies in the sample code in Usage section.