### PR TITLE
feat: add `proxyRequest` util

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ H3 has concept of compasable utilities that accept `event` (from `eventHandler((
 - `assertMethod(event, expected, allowHead?)`
 - `createError({ statusCode, statusMessage, data? })`
 - `sendProxy(event, { target, headers?, fetchOptions?, fetch?, sendStream? })`
+- `proxyRequest(event, { target, headers?, fetchOptions?, fetch?, sendStream? })`
 
 👉 You can learn more about usage in [JSDocs Documentation](https://www.jsdocs.io/package/h3#package-functions).
 

--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -11,6 +11,13 @@ export interface ProxyOptions {
 }
 
 const PayloadMethods = ['PATCH', 'POST', 'PUT', 'DELETE']
+const ignoredHeaders = [
+  'transfer-encoding',
+  'connection',
+  'keep-alive',
+  'upgrade',
+  'expect'
+]
 
 export async function proxyRequest (event: H3Event, target: string, opts: ProxyOptions = {}) {
   // Method
@@ -26,7 +33,9 @@ export async function proxyRequest (event: H3Event, target: string, opts: ProxyO
   const headers = Object.create(null)
   const reqHeaders = getRequestHeaders(event)
   for (const name in reqHeaders) {
-    headers[name] = reqHeaders[name]
+    if (!ignoredHeaders.includes(name)) {
+      headers[name] = reqHeaders[name]
+    }
   }
   if (opts.fetchOptions?.headers) {
     Object.assign(headers, opts.fetchOptions!.headers)

--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -35,16 +35,14 @@ export async function proxyRequest (event: H3Event, target: string, opts: ProxyO
     Object.assign(headers, opts.headers)
   }
 
-  const fetchOptions: RequestInit = {
-    headers,
-    method,
-    body,
-    ...opts.fetchOptions
-  }
-
   return sendProxy(event, target, {
     ...opts,
-    fetchOptions
+    fetchOptions: {
+      headers,
+      method,
+      body,
+      ...opts.fetchOptions
+    }
   })
 }
 

--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -23,11 +23,16 @@ export async function proxyRequest (event: H3Event, target: string, opts: ProxyO
   }
 
   // Headers
-  // TODO: Allow overriding headers
   const headers = Object.create(null)
   const reqHeaders = getRequestHeaders(event)
   for (const name in reqHeaders) {
     headers[name] = reqHeaders[name]
+  }
+  if (opts.fetchOptions?.headers) {
+    Object.assign(headers, opts.fetchOptions!.headers)
+  }
+  if (opts.headers) {
+    Object.assign(headers, opts.headers)
   }
 
   const fetchOptions: RequestInit = {

--- a/test/proxy.test.ts
+++ b/test/proxy.test.ts
@@ -1,16 +1,27 @@
+import { Server } from 'node:http'
 import supertest, { SuperTest, Test } from 'supertest'
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { fetch } from 'node-fetch-native'
-import { createApp, toNodeListener, App, eventHandler } from '../src'
-import { sendProxy } from '../src/utils/proxy'
+import { createApp, toNodeListener, App, eventHandler, getHeaders, getMethod, readRawBody } from '../src'
+import { sendProxy, proxyRequest } from '../src/utils/proxy'
 
 describe('', () => {
   let app: App
   let request: SuperTest<Test>
 
-  beforeEach(() => {
+  let server: Server
+  let url: string
+
+  beforeEach(async () => {
     app = createApp({ debug: false })
     request = supertest(toNodeListener(app))
+    server = new Server(toNodeListener(app))
+    await new Promise((resolve) => { server.listen(0, () => resolve(null)) })
+    url = 'http://localhost:' + (server.address() as any).port
+  })
+
+  afterEach(async () => {
+    await new Promise((resolve) => { server.close(() => resolve(null)) })
   })
 
   describe('sendProxy', () => {
@@ -19,10 +30,36 @@ describe('', () => {
         return sendProxy(event, 'https://example.com', { fetch })
       }))
 
-      const result = await request
-        .get('/')
+      const result = await request.get('/')
 
       expect(result.text).toContain('a href="https://www.iana.org/domains/example">More information...</a>')
+    })
+  })
+
+  describe('proxyRequest', () => {
+    it('can proxy request', async () => {
+      app.use('/debug', eventHandler(async (event) => {
+        const headers = getHeaders(event)
+        delete headers.host
+        let body
+        try { body = await readRawBody(event) } catch {}
+        return {
+          method: getMethod(event),
+          headers,
+          body
+        }
+      }))
+
+      app.use('/', eventHandler((event) => {
+        return proxyRequest(event, url + '/debug', { fetch })
+      }))
+
+      const result = await fetch(url + '/', {
+        method: 'POST',
+        body: 'hello'
+      }).then(r => r.text())
+
+      expect(result).toMatchInlineSnapshot('"{\\"method\\":\\"POST\\",\\"headers\\":{\\"accept\\":\\"*/*\\",\\"accept-encoding\\":\\"gzip, deflate, br\\",\\"connection\\":\\"close\\",\\"content-length\\":\\"5\\",\\"content-type\\":\\"text/plain;charset=UTF-8\\",\\"user-agent\\":\\"node-fetch\\"},\\"body\\":\\"hello\\"}"')
     })
   })
 })


### PR DESCRIPTION
Resolves #224 (Thanks @P4sca1 for suggestion)

This PR adds a new `proxyRequest` utility built on top of `sendProxy` that proxies incoming request headers, body and method to target. (path is not rewritten)