### PR TITLE
refactor: move `event.req` and `event.res` to `event.node.*`

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Routes are internally stored in a [Radix Tree](https://en.wikipedia.org/wiki/Rad
 
 ```js
 // Handle can directly return object or Promise<object> for JSON response
-app.use('/api', eventHandler((event) => ({ url: event.req.url }))
+app.use('/api', eventHandler((event) => ({ url: event.node.req.url }))
 
 // We can have better matching other than quick prefix match
 app.use('/odd', eventHandler(() => 'Is odd!'), { match: url => url.substr(1) % 2 })

--- a/src/error.ts
+++ b/src/error.ts
@@ -84,7 +84,7 @@ export function createError (input: string | Partial<H3Error> & { status?: numbe
  *  In the debug mode the stack trace of errors will be return in response.
  */
 export function sendError (event: H3Event, error: Error | H3Error, debug?: boolean) {
-  if (event.res.writableEnded) { return; }
+  if (event.node.res.writableEnded) { return; }
 
   const h3Error = isError(error) ? error : createError(error);
 
@@ -99,16 +99,16 @@ export function sendError (event: H3Event, error: Error | H3Error, debug?: boole
     responseBody.stack = (h3Error.stack || "").split("\n").map(l => l.trim());
   }
 
-  if (event.res.writableEnded) { return; }
+  if (event.node.res.writableEnded) { return; }
   const _code = Number.parseInt(h3Error.statusCode as unknown as string);
   if (_code) {
-    event.res.statusCode = _code;
+    event.node.res.statusCode = _code;
   }
   if (h3Error.statusMessage) {
-    event.res.statusMessage = h3Error.statusMessage;
+    event.node.res.statusMessage = h3Error.statusMessage;
   }
-  event.res.setHeader("content-type", MIMES.json);
-  event.res.end(JSON.stringify(responseBody, undefined, 2));
+  event.node.res.setHeader("content-type", MIMES.json);
+  event.node.res.end(JSON.stringify(responseBody, undefined, 2));
 }
 
 export function isError (input: any): input is H3Error {

--- a/src/event/event.ts
+++ b/src/event/event.ts
@@ -3,15 +3,32 @@ import type { NodeIncomingMessage, NodeServerResponse } from "../node";
 import { MIMES } from "../utils";
 import { H3Response } from "./response";
 
-export class H3Event implements Pick<FetchEvent, "respondWith"> {
-  "__is_event__" = true;
+export interface NodeEventContext {
   req: NodeIncomingMessage;
   res: NodeServerResponse;
+}
+
+export class H3Event implements Pick<FetchEvent, "respondWith"> {
+  "__is_event__" = true;
+  node: NodeEventContext;
   context: H3EventContext = {};
 
   constructor (req: NodeIncomingMessage, res: NodeServerResponse) {
-    this.req = req;
-    this.res = res;
+    this.node = { req, res };
+  }
+
+  get path () {
+    return this.req.url;
+  }
+
+  /** @deprecated Please use `event.node.res` instead. **/
+  get req () {
+    return this.node.req;
+  }
+
+  /** @deprecated Please use `event.node.res` instead. **/
+  get res () {
+    return this.node.res;
   }
 
   // Implementation of FetchEvent

--- a/src/node.ts
+++ b/src/node.ts
@@ -22,7 +22,7 @@ export function fromNodeMiddleware (handler: NodeListener | NodeMiddleware): Eve
     throw new (TypeError as any)("Invalid handler. It should be a function:", handler);
   }
   return eventHandler((event) => {
-    return callNodeListener(handler, event.req as NodeIncomingMessage, event.res) as EventHandlerResponse;
+    return callNodeListener(handler, event.node.req as NodeIncomingMessage, event.node.res) as EventHandlerResponse;
   });
 }
 

--- a/src/router.ts
+++ b/src/router.ts
@@ -52,7 +52,7 @@ export function createRouter (opts: CreateRouterOptions = {}): Router {
   // Main handle
   router.handler = eventHandler((event) => {
     // Remove query parameters for matching
-    let path = event.req.url || "/";
+    let path = event.node.req.url || "/";
     const qIndex = path.indexOf("?");
     if (qIndex !== -1) {
       path = path.slice(0, Math.max(0, qIndex));
@@ -65,7 +65,7 @@ export function createRouter (opts: CreateRouterOptions = {}): Router {
         throw createError({
           statusCode: 404,
           name: "Not Found",
-          statusMessage: `Cannot find any route matching ${event.req.url || "/"}.`
+          statusMessage: `Cannot find any route matching ${event.node.req.url || "/"}.`
         });
       } else {
         return; // Let app match other handlers
@@ -73,7 +73,7 @@ export function createRouter (opts: CreateRouterOptions = {}): Router {
     }
 
     // Match method
-    const method = (event.req.method || "get").toLowerCase() as RouterMethod;
+    const method = (event.node.req.method || "get").toLowerCase() as RouterMethod;
     const handler = matched.handlers[method] || matched.handlers.all;
     if (!handler) {
       throw createError({

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -22,26 +22,26 @@ export function handleCacheHeaders (event: H3Event, opts: CacheConditions): bool
 
   if (opts.modifiedTime) {
     const modifiedTime = new Date(opts.modifiedTime);
-    const ifModifiedSince = event.req.headers["if-modified-since"];
-    event.res.setHeader("last-modified", modifiedTime.toUTCString());
+    const ifModifiedSince = event.node.req.headers["if-modified-since"];
+    event.node.res.setHeader("last-modified", modifiedTime.toUTCString());
     if (ifModifiedSince && new Date(ifModifiedSince) >= opts.modifiedTime) {
       cacheMatched = true;
     }
   }
 
   if (opts.etag) {
-    event.res.setHeader("etag", opts.etag);
-    const ifNonMatch = event.req.headers["if-none-match"];
+    event.node.res.setHeader("etag", opts.etag);
+    const ifNonMatch = event.node.req.headers["if-none-match"];
     if (ifNonMatch === opts.etag) {
       cacheMatched = true;
     }
   }
 
-  event.res.setHeader("cache-control", cacheControls.join(", "));
+  event.node.res.setHeader("cache-control", cacheControls.join(", "));
 
   if (cacheMatched) {
-    event.res.statusCode = 304;
-    event.res.end();
+    event.node.res.statusCode = 304;
+    event.node.res.end();
     return true;
   }
 

--- a/src/utils/cookie.ts
+++ b/src/utils/cookie.ts
@@ -12,7 +12,7 @@ import { appendHeader } from "./response";
  * ```
  */
 export function parseCookies (event: H3Event): Record<string, string> {
-  return parse(event.req.headers.cookie || "");
+  return parse(event.node.req.headers.cookie || "");
 }
 
 /**

--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -65,29 +65,29 @@ export async function sendProxy (event: H3Event, target: string, opts: ProxyOpti
     headers: opts.headers as HeadersInit,
     ...opts.fetchOptions
   });
-  event.res.statusCode = response.status;
-  event.res.statusMessage = response.statusText;
+  event.node.res.statusCode = response.status;
+  event.node.res.statusMessage = response.statusText;
 
   for (const [key, value] of response.headers.entries()) {
     if (key === "content-encoding") { continue; }
     if (key === "content-length") { continue; }
-    event.res.setHeader(key, value);
+    event.node.res.setHeader(key, value);
   }
 
   try {
     if (response.body) {
       if (opts.sendStream === false) {
         const data = new Uint8Array(await response.arrayBuffer());
-        event.res.end(data);
+        event.node.res.end(data);
       } else {
         for await (const chunk of response.body as any as AsyncIterable<Uint8Array>) {
-          event.res.write(chunk);
+          event.node.res.write(chunk);
         }
-        event.res.end();
+        event.node.res.end();
       }
     }
   } catch (error) {
-    event.res.end();
+    event.node.res.end();
     throw error;
   }
 }

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -4,7 +4,7 @@ import type { HTTPMethod, RequestHeaders } from "../types";
 import type { H3Event } from "../event";
 
 export function getQuery (event: H3Event) {
-  return _getQuery(event.req.url || "");
+  return _getQuery(event.node.req.url || "");
 }
 
 export function getRouterParams (event: H3Event): H3Event["context"] {
@@ -19,7 +19,7 @@ export function getRouterParam (event: H3Event, name: string): H3Event["context"
 }
 
 export function getMethod (event: H3Event, defaultMethod: HTTPMethod = "GET"): HTTPMethod {
-  return (event.req.method || defaultMethod).toUpperCase() as HTTPMethod;
+  return (event.node.req.method || defaultMethod).toUpperCase() as HTTPMethod;
 }
 
 export function isMethod (event: H3Event, expected: HTTPMethod | HTTPMethod[], allowHead?: boolean) {
@@ -51,8 +51,8 @@ export function assertMethod (event: H3Event, expected: HTTPMethod | HTTPMethod[
 
 export function getRequestHeaders (event: H3Event): RequestHeaders {
   const _headers: RequestHeaders = {};
-  for (const key in event.req.headers) {
-    const val = event.req.headers[key];
+  for (const key in event.node.req.headers) {
+    const val = event.node.req.headers[key];
     _headers[key] = Array.isArray(val) ? val.filter(Boolean).join(", ") : val;
   }
   return _headers;

--- a/src/utils/route.ts
+++ b/src/utils/route.ts
@@ -6,8 +6,8 @@ export function useBase (base: string, handler: EventHandler): EventHandler {
   base = withoutTrailingSlash(base);
   if (!base) { return handler; }
   return eventHandler((event) => {
-    (event.req as any).originalUrl = (event.req as any).originalUrl || event.req.url || "/";
-    event.req.url = withoutBase(event.req.url || "/", base);
+    (event.node.req as any).originalUrl = (event.node.req as any).originalUrl || event.node.req.url || "/";
+    event.node.req.url = withoutBase(event.node.req.url || "/", base);
     return handler(event);
   });
 }

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -13,7 +13,7 @@ describe("app", () => {
   });
 
   it("can return JSON directly", async () => {
-    app.use("/api", eventHandler(event => ({ url: event.req.url })));
+    app.use("/api", eventHandler(event => ({ url: event.node.req.url })));
     const res = await request.get("/api");
 
     expect(res.body).toEqual({ url: "/" });
@@ -86,7 +86,7 @@ describe("app", () => {
 
   it("allows overriding Content-Type", async () => {
     app.use(eventHandler((event) => {
-      event.res.setHeader("content-type", "text/xhtml");
+      event.node.res.setHeader("content-type", "text/xhtml");
       return "<h1>Hello world!</h1>";
     }));
     const res = await request.get("/");
@@ -163,7 +163,7 @@ describe("app", () => {
   });
 
   it("can short-circuit route matching", async () => {
-    app.use(eventHandler((event) => { event.res.end("done"); }));
+    app.use(eventHandler((event) => { event.node.res.end("done"); }));
     app.use(eventHandler(() => "valid"));
 
     const response = await request.get("/");

--- a/test/header.test.ts
+++ b/test/header.test.ts
@@ -32,7 +32,7 @@ describe("", () => {
     it("can return request headers", async () => {
       app.use("/", eventHandler((event) => {
         const headers = getRequestHeaders(event);
-        expect(headers).toEqual(event.req.headers);
+        expect(headers).toEqual(event.node.req.headers);
       }));
       await request.get("/").set("Accept", "application/json");
     });
@@ -42,7 +42,7 @@ describe("", () => {
     it("can return request headers", async () => {
       app.use("/", eventHandler((event) => {
         const headers = getHeaders(event);
-        expect(headers).toEqual(event.req.headers);
+        expect(headers).toEqual(event.node.req.headers);
       }));
       await request.get("/").set("Accept", "application/json");
     });

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -23,13 +23,13 @@ describe("", () => {
 
   describe("useBase", () => {
     it("can prefix routes", async () => {
-      app.use("/", useBase("/api", eventHandler(event => Promise.resolve(event.req.url || "none"))));
+      app.use("/", useBase("/api", eventHandler(event => Promise.resolve(event.node.req.url || "none"))));
       const result = await request.get("/api/test");
 
       expect(result.text).toBe("/test");
     });
     it("does nothing when not provided a base", async () => {
-      app.use("/", useBase("", eventHandler(event => Promise.resolve(event.req.url || "none"))));
+      app.use("/", useBase("", eventHandler(event => Promise.resolve(event.node.req.url || "none"))));
       const result = await request.get("/api/test");
 
       expect(result.text).toBe("/api/test");


### PR DESCRIPTION
Ref #73

Using soft deprecation to use `event.node.req` and `event.node.res` instead of `event.req` and `event.res` preparing users for next iterations.

A new `event.path` getter also added to make accessing to path easier. (used `path` instead of `url` to avoid confusing hostname inclusion)