### PR TITLE
docs: fix deprecated methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,13 +113,13 @@ H3 has concept of compasable utilities that accept `event` (from `eventHandler((
 
 ### Built-in
 
-- `useRawBody(event, encoding?)`
-- `useBody(event)`
-- `useCookies(event)`
-- `useCookie(event, name)`
+- `readRawBody(event, encoding?)`
+- `readBody(event)`
+- `parseCookies(event)`
+- `getCookie(event, name)`
 - `setCookie(event, name, value, opts?)`
 - `deleteCookie(event, name, opts?)`
-- `useQuery(event)`
+- `getQuery(event)`
 - `getRouterParams(event)`
 - `send(event, data, type?)`
 - `sendRedirect(event, location, code=302)`
@@ -132,7 +132,7 @@ H3 has concept of compasable utilities that accept `event` (from `eventHandler((
 - `writeEarlyHints(event, links, callback)`
 - `sendStream(event, data)`
 - `sendError(event, error, debug?)`
-- `useMethod(event, default?)`
+- `getMethod(event, default?)`
 - `isMethod(event, expected, allowHead?)`
 - `assertMethod(event, expected, allowHead?)`
 - `createError({ statusCode, statusMessage, data? })`


### PR DESCRIPTION
Resolves #236.

I replaced deprecated methods in README according to the commit dc8ee81799bf93148ef686b3434287858afdafa0.

I also searched the word `deprecated` in VS Code just in case, and consequently there seems to be no more deprecated methods in the code base.