### PR TITLE
fix(readBody): handle top-level arrays in url-encoded data

### DIFF
--- a/src/utils/body.ts
+++ b/src/utils/body.ts
@@ -67,14 +67,14 @@ export async function readBody<T=any> (event: H3Event): Promise<T> {
     const form = new URLSearchParams(body);
     const parsedForm: Record<string, any> = Object.create(null);
     for (const [key, value] of form.entries()) {
-      if (!(key in parsedForm)) {
+      if ((key in parsedForm)) {
+        if (!Array.isArray(parsedForm[key])) {
+          parsedForm[key] = [parsedForm[key]];
+        }
+        parsedForm[key].push(value);
+      } else {
         parsedForm[key] = value;
-        continue;
       }
-      if (!Array.isArray(parsedForm[key])) {
-        parsedForm[key] = [parsedForm[key]];
-      }
-      parsedForm[key].push(value);
     }
     return parsedForm as unknown as T;
   }

--- a/src/utils/body.ts
+++ b/src/utils/body.ts
@@ -64,7 +64,16 @@ export async function readBody<T=any> (event: H3Event): Promise<T> {
   const body = await readRawBody(event) as string;
 
   if (event.node.req.headers["content-type"] === "application/x-www-form-urlencoded") {
-    const parsedForm = Object.fromEntries(new URLSearchParams(body));
+    const form = new URLSearchParams(body);
+    const parsedForm: Record<string, any> = {};
+    for (const [key, value] of form.entries()) {
+      if (key in parsedForm && !Array.isArray(parsedForm[key])) {
+        parsedForm[key] = [parsedForm[key]];
+        parsedForm[key].push(value);
+      } else {
+        parsedForm[key] = value;
+      }
+    }
     return parsedForm as unknown as T;
   }
 

--- a/src/utils/body.ts
+++ b/src/utils/body.ts
@@ -67,12 +67,14 @@ export async function readBody<T=any> (event: H3Event): Promise<T> {
     const form = new URLSearchParams(body);
     const parsedForm: Record<string, any> = Object.create(null);
     for (const [key, value] of form.entries()) {
-      if (key in parsedForm && !Array.isArray(parsedForm[key])) {
-        parsedForm[key] = [parsedForm[key]];
-        parsedForm[key].push(value);
-      } else {
+      if (!(key in parsedForm)) {
         parsedForm[key] = value;
+        continue;
       }
+      if (!Array.isArray(parsedForm[key])) {
+        parsedForm[key] = [parsedForm[key]];
+      }
+      parsedForm[key].push(value);
     }
     return parsedForm as unknown as T;
   }

--- a/src/utils/body.ts
+++ b/src/utils/body.ts
@@ -65,7 +65,7 @@ export async function readBody<T=any> (event: H3Event): Promise<T> {
 
   if (event.node.req.headers["content-type"] === "application/x-www-form-urlencoded") {
     const form = new URLSearchParams(body);
-    const parsedForm: Record<string, any> = {};
+    const parsedForm: Record<string, any> = Object.create(null);
     for (const [key, value] of form.entries()) {
       if (key in parsedForm && !Array.isArray(parsedForm[key])) {
         parsedForm[key] = [parsedForm[key]];

--- a/src/utils/body.ts
+++ b/src/utils/body.ts
@@ -67,7 +67,7 @@ export async function readBody<T=any> (event: H3Event): Promise<T> {
     const form = new URLSearchParams(body);
     const parsedForm: Record<string, any> = Object.create(null);
     for (const [key, value] of form.entries()) {
-      if ((key in parsedForm)) {
+      if (key in parsedForm) {
         if (!Array.isArray(parsedForm[key])) {
           parsedForm[key] = [parsedForm[key]];
         }

--- a/test/body.test.ts
+++ b/test/body.test.ts
@@ -118,12 +118,12 @@ describe("", () => {
         expect(body).toMatchObject({
           field: "value",
           another: "true",
-          number: ["20", "30"]
+          number: ["20", "30", "40"]
         });
         return "200";
       }));
       const result = await request.post("/api/test")
-        .send("field=value&another=true&number=20&number=30");
+        .send("field=value&another=true&number=20&number=30&number=40");
 
       expect(result.text).toBe("200");
     });

--- a/test/body.test.ts
+++ b/test/body.test.ts
@@ -118,12 +118,12 @@ describe("", () => {
         expect(body).toMatchObject({
           field: "value",
           another: "true",
-          number: "20"
+          number: ["20", "30"]
         });
         return "200";
       }));
       const result = await request.post("/api/test")
-        .send("field=value&another=true&number=20");
+        .send("field=value&another=true&number=20&number=30");
 
       expect(result.text).toBe("200");
     });


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/unjs/h3/issues/275

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Previously a valid url-encoded string with multiple entries for the same value was not properly parsed. This creates arrays in such cases; it still doesn't support advanced nested arrays like `qs` but handles this specification as expected.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
