### PR TITLE
test: replace useCookies with parseCookies in describe

### DIFF
--- a/test/cookie.test.ts
+++ b/test/cookie.test.ts
@@ -12,7 +12,7 @@ describe("", () => {
     request = supertest(toNodeListener(app));
   });
 
-  describe("useCookies", () => {
+  describe("parseCookies", () => {
     it("can parse cookies", async () => {
       app.use(
         "/",


### PR DESCRIPTION
It seems that `useCookies` was replaced with `parseCookies` in 56bfe0ae7eea72051f6aa2ac838e3c947d365329 and dc8ee81799bf93148ef686b3434287858afdafa0. I found `useCookies` in `describe` of `test/cookie.test.ts` and replaced it with `parseCookies`.

I've confirmed `useCookies` doesn't exist except in CHANGELOG.

```
$ git grep useCookies
CHANGELOG.md:* `useCookie`, `useCookies` and `setCookie` utilities ([088f413](https://github.com/unjs/h3/commit/088f413434a619a9888bfd9d1b189e56a7d00124)), closes [#17](https://github.com/unjs/h3/issues/17)
```