### PR TITLE
feat: session support

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,9 +1,8 @@
 {
-  "extends": [
-    "eslint-config-unjs"
-  ],
+  "extends": ["eslint-config-unjs"],
   "rules": {
     "unicorn/no-null": "off",
-    "unicorn/number-literal-case": "off"
+    "unicorn/number-literal-case": "off",
+    "@typescript-eslint/no-non-null-assertion": "off"
   }
 }

--- a/README.md
+++ b/README.md
@@ -153,6 +153,10 @@ H3 has a concept of composable utilities that accept `event` (from `eventHandler
 - `getResponseStatus(event)`
 - `getResponseStatusText(event)`
 - `readMultipartFormData(event)`
+- `useSession(event, { password, name?, cookie?, seal?, crypto? })`
+- `getSession(event, { password, name?, cookie?, seal?, crypto? })`
+- `updateSession(event, { password, name?, cookie?, seal?, crypto? }), update)`
+- `clearSession(event, { password, name?, cookie?, seal?, crypto? }))`
 
 👉 You can learn more about usage in [JSDocs Documentation](https://www.jsdocs.io/package/h3#package-functions).
 

--- a/package.json
+++ b/package.json
@@ -31,8 +31,10 @@
   "dependencies": {
     "cookie-es": "^0.5.0",
     "destr": "^1.2.2",
+    "iron-webcrypto": "^0.2.7",
     "radix3": "^1.0.0",
-    "ufo": "^1.0.1"
+    "ufo": "^1.0.1",
+    "uncrypto": "^0.1.2"
   },
   "devDependencies": {
     "0x": "^5.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,7 @@ specifiers:
   eslint-config-unjs: ^0.1.0
   express: ^4.18.2
   get-port: ^6.1.2
+  iron-webcrypto: ^0.2.7
   jiti: ^1.16.2
   listhen: ^1.0.2
   node-fetch-native: ^1.0.1
@@ -24,13 +25,16 @@ specifiers:
   typescript: ^4.9.5
   ufo: ^1.0.1
   unbuild: ^1.1.1
+  uncrypto: ^0.1.2
   vitest: ^0.28.3
 
 dependencies:
   cookie-es: 0.5.0
   destr: 1.2.2
+  iron-webcrypto: 0.2.7
   radix3: 1.0.0
   ufo: 1.0.1
+  uncrypto: 0.1.2
 
 devDependencies:
   0x: 5.4.1
@@ -1232,7 +1236,6 @@ packages:
 
   /base64-js/1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
-    dev: true
 
   /bn.js/4.12.0:
     resolution: {integrity: sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==}
@@ -1443,6 +1446,13 @@ packages:
       base64-js: 1.5.1
       ieee754: 1.2.1
     dev: true
+
+  /buffer/6.0.3:
+    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+    dev: false
 
   /builtin-modules/3.3.0:
     resolution: {integrity: sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==}
@@ -3528,7 +3538,6 @@ packages:
 
   /ieee754/1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
-    dev: true
 
   /ignore/5.2.0:
     resolution: {integrity: sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==}
@@ -3612,6 +3621,12 @@ packages:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
     dev: true
+
+  /iron-webcrypto/0.2.7:
+    resolution: {integrity: sha512-RUIWryBN8tlyozRLV//J3SDEywa8wfUEDXIjckweo6BCp8fklwArYRr88kaWK5bWP72/B5N1EWGMtpUQhm5oVw==}
+    dependencies:
+      buffer: 6.0.3
+    dev: false
 
   /is-arguments/1.1.1:
     resolution: {integrity: sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==}
@@ -5694,6 +5709,10 @@ packages:
       - sass
       - supports-color
     dev: true
+
+  /uncrypto/0.1.2:
+    resolution: {integrity: sha512-kuZwRKV615lEw/Xx3Iz56FKk3nOeOVGaVmw0eg+x4Mne28lCotNFbBhDW7dEBCBKyKbRQiCadEZeNAFPVC5cgw==}
+    dev: false
 
   /undeclared-identifiers/1.1.3:
     resolution: {integrity: sha512-pJOW4nxjlmfwKApE4zvxLScM/njmwj/DiUBv7EabwE4O8kRUy+HIwxQtZLBPll/jx1LJyBcqNfB3/cpv9EZwOw==}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import type { H3Event } from "./event";
+import { Session } from "./utils/session";
 
 // https://www.rfc-editor.org/rfc/rfc7231#section-4.1
 export type HTTPMethod =
@@ -25,8 +26,12 @@ export type Encoding =
   | "binary"
   | "hex";
 
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface H3EventContext extends Record<string, any> {}
+export interface H3EventContext extends Record<string, any> {
+  /* Matched router parameters */
+  params?: Record<string, string>;
+  /* Cached session data */
+  sessions?: Record<string, Session>;
+}
 
 export type EventHandlerResponse<T = any> = T | Promise<T>;
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -6,3 +6,4 @@ export * from "./cookie";
 export * from "./proxy";
 export * from "./request";
 export * from "./response";
+export * from "./session";

--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -1,0 +1,130 @@
+import { seal, unseal, defaults as sealDefaults } from "iron-webcrypto";
+import type { SealOptions } from "iron-webcrypto";
+import type { CookieSerializeOptions, CookieParseOptions } from "cookie-es";
+import crypto from "uncrypto";
+import type { H3Event } from "../event";
+import { getCookie, setCookie } from "./cookie";
+
+type SessionDataT = Record<string, string | number | boolean>;
+export type SessionData<T extends SessionDataT = SessionDataT> = T;
+
+export interface Session<T extends SessionDataT = SessionDataT> {
+  id: string;
+  data: SessionData<T>;
+}
+
+export interface SessionConfig {
+  password: string;
+  name?: string;
+  cookie?: CookieSerializeOptions & CookieParseOptions;
+  seal?: SealOptions;
+  crypto?: Crypto;
+}
+
+export async function useSession<T extends SessionDataT = SessionDataT>(
+  event: H3Event,
+  config: SessionConfig
+) {
+  // Create a synced wrapper around the session
+  const sessionName = config.name || "h3";
+  await getSession(event, config); // Force init
+  const sessionManager = {
+    get id() {
+      return event.context.sessions?.[sessionName]?.id;
+    },
+    get data() {
+      return event.context.sessions?.[sessionName]?.data || {};
+    },
+    update: async (update: SessionUpdate<T>) => {
+      await updateSession<T>(event, config, update);
+      return sessionManager;
+    },
+    clear: async () => {
+      await clearSession(event, config);
+      return sessionManager;
+    },
+  };
+  return sessionManager;
+}
+
+export async function getSession<T extends SessionDataT = SessionDataT>(
+  event: H3Event,
+  config: SessionConfig
+): Promise<Session<T>> {
+  const sessionName = config.name || "h3";
+
+  // Return existing session if available
+  if (!event.context.sessions) {
+    event.context.sessions = Object.create(null);
+  }
+  if (event.context.sessions![sessionName]) {
+    return event.context.sessions![sessionName] as Session<T>;
+  }
+
+  // Prepare an empty session object and store in context
+  const session: Session<T> = { id: "", data: Object.create(null) };
+  event.context.sessions![sessionName] = session;
+
+  // Try to hydrate from cookies
+  const reqCookie = getCookie(event, sessionName);
+  if (!reqCookie) {
+    // New session store in response cookies
+    session.id = (config.crypto || crypto).randomUUID();
+    await updateSession(event, config);
+  } else {
+    // Unseal session data from cookie
+    const unsealed = await unseal(
+      config.crypto || crypto,
+      reqCookie,
+      config.password,
+      config.seal || sealDefaults
+    );
+    Object.assign(session, unsealed);
+  }
+
+  return session;
+}
+
+type SessionUpdate<T extends SessionDataT = SessionDataT> =
+  | Partial<SessionData<T>>
+  | ((oldData: SessionData<T>) => Partial<SessionData<T>> | undefined);
+
+export async function updateSession<T extends SessionDataT = SessionDataT>(
+  event: H3Event,
+  config: SessionConfig,
+  update?: SessionUpdate<T>
+): Promise<Session<T>> {
+  const sessionName = config.name || "h3";
+
+  // Access current session
+  const session: Session<T> =
+    (event.context.sessions?.[sessionName] as Session<T>) ||
+    (await getSession<T>(event, config));
+
+  // Update session data if provided
+  if (typeof update === "function") {
+    update = update(session.data);
+  }
+  if (update) {
+    Object.assign(session.data, update);
+  }
+
+  // Seal and store in cookie
+  const sealed = await seal(
+    config.crypto || crypto,
+    session,
+    config.password,
+    config.seal || sealDefaults
+  );
+  setCookie(event, sessionName, sealed, config.cookie);
+
+  return session;
+}
+
+export async function clearSession(event: H3Event, config: SessionConfig) {
+  const sessionName = config.name || "h3";
+  if (event.context.sessions?.[sessionName]) {
+    delete event.context.sessions![sessionName];
+  }
+  await setCookie(event, sessionName, "", config.cookie);
+}

--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -25,6 +25,7 @@ const DEFAULT_NAME = "h3";
 const DEFAULT_COOKIE: SessionConfig["cookie"] = {
   path: "/",
   secure: true,
+  httpOnly: true,
 };
 
 export async function useSession<T extends SessionDataT = SessionDataT>(


### PR DESCRIPTION
Resolves #58

This PR adds basic session support. Sessions are sealed (encrypted and signed with a private key) in cookies using [iron-webcrypto](https://github.com/brc-dd/iron-webcrypto) (thanks @brc-dd ❤️) and [uncrypto](https://github.com/unjs/uncrypto) to work out of with Node.js and other environments.

The encrypted session is carried over cookies, therefore no server storage is required for session support.

Multiple session support is also possible with this implementation and custom `name` option (default is `h3` and used for cookie name as well )

Default cookie options are secure, httpOnly with path of `/` (can be configured)

Exposed utils:
- `useSession`: Initializes session and returns an `{ data, id, update(val), clear() }` interface to manage session. Wrapping `getSession`, `upsteSession` and `clearSession`
- `getSession`: Treis to reuse or otherwise init an empty session for user
- `updateSession`: Updates session both in cookie and context. Also initializes if not initialized yet
- `clearSession`: Clears session from both cookie and context

Simple usage:

```js
import { useSession } from 'h3'

const sessionPassword = "secretsecretsecretsecretsecretsecretsecret"

export default eventHandler(async (event) => {
      const session = await useSession<{ ctr: number }>(event, { password });
      await session.update((data) => ({ ctr: Number(data.ctr || 0) + 2 }));
      await session.update({ ctr: Number(session.data.ctr || 0) - 1 });
      return `Hello! You visited this page ${session.data.ctr} times. session id: ${session.id})`;
})
```

Known issues:
 - each updates appends a new cookie. fixing in second PR