### PR TITLE
fix(setCookie): override existing `set-cookie` header with same name

### DIFF
--- a/src/utils/cookie.ts
+++ b/src/utils/cookie.ts
@@ -48,7 +48,14 @@ export function setCookie(
     path: "/",
     ...serializeOptions,
   });
-  appendHeader(event, "Set-Cookie", cookieStr);
+  let setCookies = event.node.res.getHeader("set-cookie");
+  if (!Array.isArray(setCookies)) {
+    setCookies = [setCookies as any];
+  }
+  setCookies = setCookies.filter((cookieValue: string) => {
+    return cookieValue && !cookieValue.startsWith(name + "=");
+  });
+  event.node.res.setHeader("set-cookie", [...setCookies, cookieStr]);
 }
 
 /**


### PR DESCRIPTION
When calling `setCookie` in same event multiple times with same name, it will add multiple `set-cookie` header updates. while this works on browser this remove old headers instead.