### PR TITLE
feat: `fetchWithEvent` and `getProxyRequestHeaders` utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ H3 has a concept of composable utilities that accept `event` (from `eventHandler
 - `createError({ statusCode, statusMessage, data? })`
 - `sendProxy(event, { target, headers?, fetchOptions?, fetch?, sendStream? })`
 - `proxyRequest(event, { target, headers?, fetchOptions?, fetch?, sendStream? })`
+- `fetchWithEvent(event, req, init, { fetch? }?)`
+- `getProxyRequestHeaders(event)`
 - `sendNoContent(event, code = 204)`
 - `setResponseStatus(event, status)`
 - `getResponseStatus(event)`

--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -90,19 +90,19 @@ export async function sendProxy(
   }
 
   try {
-    if (response.body) {
-      if (opts.sendStream === false) {
-        const data = new Uint8Array(await response.arrayBuffer());
-        event.node.res.end(data);
-      } else {
-        for await (const chunk of response.body as any as AsyncIterable<Uint8Array>) {
-          event.node.res.write(chunk);
-        }
-        event.node.res.end();
-      }
+    if ((response as any)._data) {
+      return event.node.res.end((response as any)._data);
     }
-  } catch (error) {
+    if (opts.sendStream === false) {
+      const data = new Uint8Array(await response.arrayBuffer());
+      return event.node.res.end(data);
+    }
+    for await (const chunk of response.body as any as AsyncIterable<Uint8Array>) {
+      event.node.res.write(chunk);
+    }
     event.node.res.end();
+  } catch (error) {
+    event.node.res.end((response as any)._data);
     throw error;
   }
 }

--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -113,6 +113,8 @@ export function fetchWithEvent(
 ) {
   return _getFetch(options?.fetch)(req, {
     ...init,
+    // @ts-ignore (context is used for unenv and local fetch)
+    context: init.context || event.context,
     headers: {
       ...getProxyRequestHeaders(event),
       ...init?.headers,


### PR DESCRIPTION
Add two new proxy utils:

- `fetchWithEvent`: A fetch wrapper that uses event's context and incoming headers to proxy
- `getProxyRequestHeaders`: Gey filtered headers from incoming header we can proxy