### PR TITLE
feat: session support improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,10 +155,12 @@ H3 has a concept of composable utilities that accept `event` (from `eventHandler
 - `getResponseStatus(event)`
 - `getResponseStatusText(event)`
 - `readMultipartFormData(event)`
-- `useSession(event, { password, name?, cookie?, seal?, crypto? })`
-- `getSession(event, { password, name?, cookie?, seal?, crypto? })`
-- `updateSession(event, { password, name?, cookie?, seal?, crypto? }), update)`
-- `clearSession(event, { password, name?, cookie?, seal?, crypto? }))`
+- `useSession(event, config = { password, maxAge?, name?, cookie?, seal?, crypto? })`
+- `getSession(event, config)`
+- `updateSession(event, config, update)`
+- `clearSession(event, config)`
+- `sealSession(event, config)`
+- `unsealSession(event, config, sealed)`
 
 👉 You can learn more about usage in [JSDocs Documentation](https://www.jsdocs.io/package/h3#package-functions).
 

--- a/playground/index.ts
+++ b/playground/index.ts
@@ -32,7 +32,10 @@ const router = createRouter()
     "/hello/:name",
     eventHandler(async (event) => {
       const password = "secretsecretsecretsecretsecretsecretsecret";
-      const session = await useSession<{ ctr: number }>(event, { password });
+      const session = await useSession<{ ctr: number }>(event, {
+        password,
+        maxAge: 5,
+      });
       await session.update((data) => ({ ctr: Number(data.ctr || 0) + 2 }));
       await session.update({ ctr: Number(session.data.ctr || 0) - 1 });
       return `Hello ${event.context.params?.name}! (you visited this page ${session.data.ctr} times. session id: ${session.id})`;

--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -10,13 +10,21 @@ export type SessionData<T extends SessionDataT = SessionDataT> = T;
 
 export interface Session<T extends SessionDataT = SessionDataT> {
   id: string;
+  createdAt: number;
   data: SessionData<T>;
 }
 
 export interface SessionConfig {
+  /** Private key used to encrypt session tokens */
   password: string;
+  /** Session expiration time in seconds */
+  maxAge?: number;
+  /** default is h3 */
   name?: string;
-  cookie?: CookieSerializeOptions;
+  /** Default is secure, httpOnly, / */
+  cookie?: false | CookieSerializeOptions;
+  /** Default is x-h3-session / x-{name}-session */
+  sessionHeader?: false | string;
   seal?: SealOptions;
   crypto?: Crypto;
 }
@@ -69,24 +77,43 @@ export async function getSession<T extends SessionDataT = SessionDataT>(
   }
 
   // Prepare an empty session object and store in context
-  const session: Session<T> = { id: "", data: Object.create(null) };
+  const session: Session<T> = {
+    id: "",
+    createdAt: 0,
+    data: Object.create(null),
+  };
   event.context.sessions![sessionName] = session;
 
-  // Try to hydrate from cookies
-  const reqCookie = getCookie(event, sessionName);
-  if (!reqCookie) {
-    // New session store in response cookies
-    session.id = (config.crypto || crypto).randomUUID();
-    await updateSession(event, config);
-  } else {
+  // Try to load session
+  let sealedSession: string | undefined;
+  // Try header first
+  if (config.sessionHeader !== false) {
+    const headerName =
+      typeof config.sessionHeader === "string"
+        ? config.sessionHeader.toLowerCase()
+        : `x-${sessionName.toLowerCase()}-session`;
+    const headerValue = event.node.req.headers[headerName];
+    if (typeof headerValue === "string") {
+      sealedSession = headerValue;
+    }
+  }
+  // Fallback to cookies
+  if (!sealedSession) {
+    sealedSession = getCookie(event, sessionName);
+  }
+  if (sealedSession) {
     // Unseal session data from cookie
-    const unsealed = await unseal(
-      config.crypto || crypto,
-      reqCookie,
-      config.password,
-      config.seal || sealDefaults
+    const unsealed = await unsealSession(event, config, sealedSession).catch(
+      () => {}
     );
     Object.assign(session, unsealed);
+  }
+
+  // New session store in response cookies
+  if (!session.id) {
+    session.id = (config.crypto || crypto).randomUUID();
+    session.createdAt = Date.now();
+    await updateSession(event, config);
   }
 
   return session;
@@ -117,15 +144,58 @@ export async function updateSession<T extends SessionDataT = SessionDataT>(
   }
 
   // Seal and store in cookie
+  if (config.cookie !== false) {
+    const sealed = await sealSession(event, config);
+    setCookie(
+      event,
+      sessionName,
+      sealed,
+      config.cookie || { ...DEFAULT_COOKIE, maxAge: config.maxAge }
+    );
+  }
+
+  return session;
+}
+
+export async function sealSession<T extends SessionDataT = SessionDataT>(
+  event: H3Event,
+  config: SessionConfig
+) {
+  const sessionName = config.name || DEFAULT_NAME;
+
+  // Access current session
+  const session: Session<T> =
+    (event.context.sessions?.[sessionName] as Session<T>) ||
+    (await getSession<T>(event, config));
+
   const sealed = await seal(
     config.crypto || crypto,
     session,
     config.password,
     config.seal || sealDefaults
   );
-  setCookie(event, sessionName, sealed, config.cookie || DEFAULT_COOKIE);
 
-  return session;
+  return sealed;
+}
+
+export async function unsealSession(
+  _event: H3Event,
+  config: SessionConfig,
+  sealed: string
+) {
+  const unsealed = (await unseal(
+    config.crypto || crypto,
+    sealed,
+    config.password,
+    config.seal || sealDefaults
+  )) as Partial<Session>;
+  if (config.maxAge) {
+    const age = Date.now() - (unsealed.createdAt || Number.NEGATIVE_INFINITY);
+    if (age > config.maxAge * 1000) {
+      throw new Error("Session expired!");
+    }
+  }
+  return unsealed;
 }
 
 export async function clearSession(event: H3Event, config: SessionConfig) {
@@ -133,5 +203,10 @@ export async function clearSession(event: H3Event, config: SessionConfig) {
   if (event.context.sessions?.[sessionName]) {
     delete event.context.sessions![sessionName];
   }
-  await setCookie(event, sessionName, "", config.cookie || DEFAULT_COOKIE);
+  await setCookie(
+    event,
+    sessionName,
+    "",
+    config.cookie || { ...DEFAULT_COOKIE, maxAge: config.maxAge }
+  );
 }


### PR DESCRIPTION
- Support `maxAge` to expire sessions
  - Stored new `session.createdAt` 
  - Cookie expiration time is based on createdAt + maxAge
  - Sealing uses maxAge
  - Unseal operaion (double) checks age
- Invalid/Expired sessions are silently dropped and renewed
- Exposed new `sealSession` (useful for generating tokens) / `unsealSessin`
- Header based auth support (default header is `x-{name}-session` / `x-h3-session`)
- Cookie can be disabled with `cookie: false`

Overall this provides a more stable session support, header authorization and expiration feature.