### PR TITLE
chore: improve `lint` npm script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 coverage
 .profile
 .idea
+.eslintcache

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   "scripts": {
     "build": "unbuild",
     "dev": "vitest",
-    "lint": "eslint --ext ts,mjs,cjs . && prettier -c src test playground",
+    "lint": "eslint --cache --ext .ts,.js,.mjs,.cjs . && prettier -c src test playground",
+    "lint:fix": "eslint --cache --ext .ts,.js,.mjs,.cjs . --fix && prettier -c src test playground -w",
     "play": "jiti ./playground/index.ts",
     "profile": "0x -o -D .profile -P 'autocannon -c 100 -p 10 -d 40 http://localhost:$PORT' ./playground/server.cjs",
     "release": "pnpm test && pnpm build && changelogen --release && pnpm publish && git push --follow-tags",


### PR DESCRIPTION
I applied the latest unjs template, where `lint:fix` npm script is available with which we can fix/format files.
I also enable ESLint cache to speed it up.