### PR TITLE
refactor: replace obsolete methods in comments / test descriptions

### DIFF
--- a/src/utils/body.ts
+++ b/src/utils/body.ts
@@ -71,7 +71,7 @@ export function readRawBody<E extends Encoding = "utf8">(
  * @return {*} The `Object`, `Array`, `String`, `Number`, `Boolean`, or `null` value corresponding to the request JSON body
  *
  * ```ts
- * const body = await useBody(req)
+ * const body = await readBody(req)
  * ```
  */
 export async function readBody<T = any>(event: H3Event): Promise<T> {

--- a/src/utils/cookie.ts
+++ b/src/utils/cookie.ts
@@ -20,7 +20,7 @@ export function parseCookies(event: H3Event): Record<string, string> {
  * @param name Name of the cookie to get
  * @returns {*} Value of the cookie (String or undefined)
  * ```ts
- * const authorization = useCookie(request, 'Authorization')
+ * const authorization = getCookie(request, 'Authorization')
  * ```
  */
 export function getCookie(event: H3Event, name: string): string | undefined {

--- a/test/body.test.ts
+++ b/test/body.test.ts
@@ -19,7 +19,7 @@ describe("", () => {
     request = supertest(toNodeListener(app));
   });
 
-  describe("useRawBody", () => {
+  describe("readRawBody", () => {
     it("can handle raw string", async () => {
       app.use(
         "/",

--- a/test/cookie.test.ts
+++ b/test/cookie.test.ts
@@ -46,7 +46,7 @@ describe("", () => {
     });
   });
 
-  describe("useCookie", () => {
+  describe("getCookie", () => {
     it("can parse cookie with name", async () => {
       app.use(
         "/",

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -60,7 +60,7 @@ describe("", () => {
     });
   });
 
-  describe("useQuery", () => {
+  describe("getQuery", () => {
     it("can parse query params", async () => {
       app.use(
         "/",
@@ -82,7 +82,7 @@ describe("", () => {
     });
   });
 
-  describe("useMethod", () => {
+  describe("getMethod", () => {
     it("can get method", async () => {
       app.use(
         "/",


### PR DESCRIPTION
The following methods are now obsolete but still used in comments and test descriptions. In this PR, I've replaced them with new ones.
ref: 56bfe0a dc8ee81

- `useRawBody` => `readRawBody`
- `useBody` => `readBody`
- `useCookies` => `parseCookies` ( already fixed by #314 )
- `useCookie` => `getCookie`
- `useQuery` => `getQuery`
- `useMethod` => `getMethod`