### PR TITLE
fix(useSession): add types for `data` property

### DIFF
--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -48,7 +48,7 @@ export async function useSession<T extends SessionDataT = SessionDataT>(
       return event.context.sessions?.[sessionName]?.id;
     },
     get data() {
-      return event.context.sessions?.[sessionName]?.data || {};
+      return (event.context.sessions?.[sessionName]?.data || {}) as T;
     },
     update: async (update: SessionUpdate<T>) => {
       await updateSession<T>(event, config, update);


### PR DESCRIPTION
Referring to the example in #315 

```js
const session = await useSession<{ ctr: number }>(event, { password: sessionPassword });
await session.update((data) => ({ ctr: Number(data.ctr || 0) + 2 }));
session.data.ctr // type hints is any
```

However, getSession().data contains the correct hints, so this should be a bug.