### PR TITLE
feat: `getRequestHost`, `getRequestProtocol` and `getRequestURL` utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,9 @@ H3 has a concept of composable utilities that accept `event` (from `eventHandler
 - `isCorsOriginAllowed(event)`
 - `appendCorsHeaders(event, options)` (see [h3-cors](https://github.com/NozomuIkuta/h3-cors) for more detail about options)
 - `appendCorsPreflightHeaders(event, options)` (see [h3-cors](https://github.com/NozomuIkuta/h3-cors) for more detail about options)
+- `getRequestHost(event, { proxy? })`
+- `getRequestProtocol(event, { proxy? })`
+- `getRequestURL(event, { proxy? })`
 
 👉 You can learn more about usage in [JSDocs Documentation](https://www.jsdocs.io/package/h3#package-functions).
 

--- a/README.md
+++ b/README.md
@@ -179,9 +179,9 @@ H3 has a concept of composable utilities that accept `event` (from `eventHandler
 - `isCorsOriginAllowed(event)`
 - `appendCorsHeaders(event, options)` (see [h3-cors](https://github.com/NozomuIkuta/h3-cors) for more detail about options)
 - `appendCorsPreflightHeaders(event, options)` (see [h3-cors](https://github.com/NozomuIkuta/h3-cors) for more detail about options)
-- `getRequestHost(event, { proxy? })`
-- `getRequestProtocol(event, { proxy? })`
-- `getRequestURL(event, { proxy? })`
+- `getRequestHost(event)`
+- `getRequestProtocol(event)`
+- `getRequestURL(event)`
 
 👉 You can learn more about usage in [JSDocs Documentation](https://www.jsdocs.io/package/h3#package-functions).
 

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -84,3 +84,27 @@ export function getRequestHeader(
 }
 
 export const getHeader = getRequestHeader;
+
+export function getRequestHost(event: H3Event, opts: { proxy?: boolean } = {}) {
+  return (
+    (opts.proxy && event.node.req.headers["x-forwarded-host"]) ||
+    event.node.req.headers.host ||
+    "localhost"
+  );
+}
+
+export function getRequestProtocol(
+  event: H3Event,
+  opts: { proxy?: boolean } = {}
+) {
+  if (opts.proxy && event.node.req.headers["x-forwarded-proto"] === "https") {
+    return "https";
+  }
+  return (event.node.req.connection as any).encrypted ? "https" : "http";
+}
+
+export function getRequestURL(event: H3Event, opts: { proxy?: boolean } = {}) {
+  const host = getRequestHost(event, opts);
+  const protocol = getRequestProtocol(event, opts);
+  return new URL(event.path || "/", `${protocol}://${host}`);
+}

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -86,14 +86,8 @@ export function getRequestHeader(
 export const getHeader = getRequestHeader;
 
 export function getRequestHost(event: H3Event) {
-  let xForwardedHost = event.node.req.headers["x-forwarded-host"] as string;
+  const xForwardedHost = event.node.req.headers["x-forwarded-host"] as string;
   if (xForwardedHost) {
-    const xForwardedPort = Number.parseInt(
-      event.node.req.headers["x-forwarded-port"] as string
-    );
-    if (xForwardedPort && !xForwardedHost.includes(":")) {
-      xForwardedHost += `:${xForwardedPort}`;
-    }
     return xForwardedHost;
   }
   return event.node.req.headers.host || "localhost";


### PR DESCRIPTION
Resolves #347

Resolves #306

Implementing [requrl](https://github.com/unjs/requrl) and [is-https](https://github.com/unjs/is-https) as `h3` built-in utils.

I had been initially thinking to expose it as `event.url` it has some DX improvements but also downside of not being able to tree-shake and also not reflecting `req.path` changes.

