### PR TITLE
fix: sanitize `statusMessage` of disallowed chars

### DIFF
--- a/src/error.ts
+++ b/src/error.ts
@@ -144,8 +144,11 @@ export function sendError(
   }
   if (h3Error.statusMessage) {
     // Allowed characters: horizontal tabs, spaces or visible ascii characters: https://www.rfc-editor.org/rfc/rfc7230#section-3.1.2
-    // eslint-disable-next-line no-control-regex
-    event.node.res.statusMessage = h3Error.statusMessage.replace(/[^\u0009\u0020-\u007E]/g, '');
+    event.node.res.statusMessage = h3Error.statusMessage.replace(
+      // eslint-disable-next-line no-control-regex
+      /[^\u0009\u0020-\u007E]/g,
+      ""
+    );
   }
   event.node.res.setHeader("content-type", MIMES.json);
   event.node.res.end(JSON.stringify(responseBody, undefined, 2));

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,5 +1,5 @@
 import type { H3Event } from "./event";
-import { MIMES } from "./utils";
+import { MIMES, setResponseStatus } from "./utils";
 
 /**
  * H3 Runtime Error
@@ -139,17 +139,7 @@ export function sendError(
     return;
   }
   const _code = Number.parseInt(h3Error.statusCode as unknown as string);
-  if (_code) {
-    event.node.res.statusCode = _code;
-  }
-  if (h3Error.statusMessage) {
-    // Allowed characters: horizontal tabs, spaces or visible ascii characters: https://www.rfc-editor.org/rfc/rfc7230#section-3.1.2
-    event.node.res.statusMessage = h3Error.statusMessage.replace(
-      // eslint-disable-next-line no-control-regex
-      /[^\u0009\u0020-\u007E]/g,
-      ""
-    );
-  }
+  setResponseStatus(event, _code, h3Error.statusMessage);
   event.node.res.setHeader("content-type", MIMES.json);
   event.node.res.end(JSON.stringify(responseBody, undefined, 2));
 }

--- a/src/error.ts
+++ b/src/error.ts
@@ -143,7 +143,9 @@ export function sendError(
     event.node.res.statusCode = _code;
   }
   if (h3Error.statusMessage) {
-    event.node.res.statusMessage = h3Error.statusMessage;
+    // Allowed characters: horizontal tabs, spaces or visible ascii characters: https://www.rfc-editor.org/rfc/rfc7230#section-3.1.2
+    // eslint-disable-next-line no-control-regex
+    event.node.res.statusMessage = h3Error.statusMessage.replace(/[^\u0009\u0020-\u007E]/g, '');
   }
   event.node.res.setHeader("content-type", MIMES.json);
   event.node.res.end(JSON.stringify(responseBody, undefined, 2));

--- a/src/utils/response.ts
+++ b/src/utils/response.ts
@@ -42,7 +42,12 @@ export function setResponseStatus(
 ): void {
   event.node.res.statusCode = code;
   if (text) {
-    event.node.res.statusMessage = text;
+    // Allowed characters: horizontal tabs, spaces or visible ascii characters: https://www.rfc-editor.org/rfc/rfc7230#section-3.1.2
+    event.node.res.statusMessage = text.replace(
+      // eslint-disable-next-line no-control-regex
+      /[^\u0009\u0020-\u007E]/g,
+      ""
+    );
   }
 }
 

--- a/src/utils/response.ts
+++ b/src/utils/response.ts
@@ -40,7 +40,9 @@ export function setResponseStatus(
   code: number,
   text?: string
 ): void {
-  event.node.res.statusCode = code;
+  if (code) {
+    event.node.res.statusCode = code;
+  }
   if (text) {
     // Allowed characters: horizontal tabs, spaces or visible ascii characters: https://www.rfc-editor.org/rfc/rfc7230#section-3.1.2
     event.node.res.statusMessage = text.replace(


### PR DESCRIPTION
### 🔗 Linked issue



### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

It will break the response if we set any of these characters by accident (e.g. if a user includes in an error message).

Related: https://github.com/nuxt/nuxt/issues/14688

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
