### PR TITLE
fix: missing parentheses on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Routes are internally stored in a [Radix Tree](https://en.wikipedia.org/wiki/Rad
 
 ```js
 // Handle can directly return object or Promise<object> for JSON response
-app.use('/api', eventHandler((event) => ({ url: event.node.req.url }))
+app.use('/api', eventHandler((event) => ({ url: event.node.req.url })))
 
 // We can have better matching other than quick prefix match
 app.use('/odd', eventHandler(() => 'Is odd!'), { match: url => url.substr(1) % 2 })
@@ -121,7 +121,7 @@ app.use('/api', eventHandler((event) => proxyRequest('https://example.com', {
   cookiePathRewrite: {
     "/": "/api"
   },
-}))
+})))
 
 // Legacy middleware with 3rd argument are automatically promisified
 app.use(fromNodeMiddleware((req, res, next) => { req.setHeader('x-foo', 'bar'); next() }))


### PR DESCRIPTION
## Hello unjs/h3 community 😄

This pull request addresses an issue with the README.md file, specifically a missing closing parentheses on lines 101 and 124 of the `More app usage examples` section. The missing parentheses caused confusion for users attempting to copy said code and resulted in errors when running the code.

To fix this issue, I have added the missing closing parentheses to the lines in question.