### PR TITLE
fix(readBody, readRawBody): handle raw body as buffer

### DIFF
--- a/src/utils/body.ts
+++ b/src/utils/body.ts
@@ -79,8 +79,12 @@ export async function readBody<T = any>(event: H3Event): Promise<T> {
     return (event.node.req as any)[ParsedBodySymbol];
   }
 
-  // TODO: Handle buffer
-  const body = (await readRawBody(event)) as string;
+  let body = (await readRawBody(event)) as string;
+
+  // Handle inconsistent `readBody` behavior in some Nitro presets
+  if (Buffer.isBuffer(body)) {
+    body = (body as Buffer).toString()
+  }
 
   if (
     event.node.req.headers["content-type"] ===

--- a/src/utils/body.ts
+++ b/src/utils/body.ts
@@ -25,13 +25,12 @@ export function readRawBody<E extends Encoding = "utf8">(
   // Ensure using correct HTTP method before attempt to read payload
   assertMethod(event, PayloadMethods);
 
-  if (
-    RawBodySymbol in event.node.req ||
-    "body" in event.node.req /* unjs/unenv #8 */
-  ) {
-    const promise = Promise.resolve(
-      (event.node.req as any)[RawBodySymbol] || (event.node.req as any).body
-    );
+  // Reuse body if already read
+  const _rawBody =
+    (event.node.req as any)[RawBodySymbol] ||
+    (event.node.req as any).body; /* unjs/unenv #8 */
+  if (_rawBody) {
+    const promise = Promise.resolve(_rawBody);
     return encoding ? promise.then((buff) => buff.toString(encoding)) : promise;
   }
 

--- a/test/body.test.ts
+++ b/test/body.test.ts
@@ -174,6 +174,26 @@ describe("", () => {
       expect(result.text).toBe("200");
     });
 
+    it("handle raw body with buffer type (unenv)", async () => {
+      app.use(
+        "/",
+        eventHandler(async (event) => {
+          // Emulate unenv
+          // @ts-ignore
+          event.node.req.body = Buffer.from("test");
+
+          const body = await readBody(event);
+          expect(body).toMatchObject("test");
+
+          return "200";
+        })
+      );
+
+      const result = await request.post("/api/test").send();
+
+      expect(result.text).toBe("200");
+    });
+
     it("parses multipart form data", async () => {
       app.use(
         "/",


### PR DESCRIPTION
- Closes #363

I'm not sure if this implementation is enough. For my use-case in [nuxt-api-party](https://nuxt-api-party.jhnn.dev/):

```ts
// https://github.com/johannschopplich/nuxt-api-party/blob/main/src/runtime/server.ts#L26
let _body = await readBody<EndpointFetchOptions>(event)

// Inconsistent `readBody` behavior in some Nitro presets
// https://github.com/unjs/nitro/issues/912
if (Buffer.isBuffer(_body))
  _body = destr((_body as Buffer).toString())
```

… this change fixed handling `Buffer` requests, e.g. when sending POST requests in a Cloudflare Nitro worker.

