### PR TITLE
feat(proxy): support `onResponse` callback

### DIFF
--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -12,6 +12,7 @@ export interface ProxyOptions {
   sendStream?: boolean;
   cookieDomainRewrite?: string | Record<string, string>;
   cookiePathRewrite?: string | Record<string, string>;
+  onResponse?: (event: H3Event) => void;
 }
 
 const PayloadMethods = new Set(["PATCH", "POST", "PUT", "DELETE"]);
@@ -103,6 +104,10 @@ export async function sendProxy(
     }
 
     event.node.res.setHeader(key, value);
+  }
+
+  if (opts.onResponse) {
+    await opts.onResponse(event);
   }
 
   // Directly send consumed _data

--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -12,7 +12,7 @@ export interface ProxyOptions {
   sendStream?: boolean;
   cookieDomainRewrite?: string | Record<string, string>;
   cookiePathRewrite?: string | Record<string, string>;
-  onResponse?: (event: H3Event) => void;
+  onResponse?: (event: H3Event, response: Response) => void;
 }
 
 const PayloadMethods = new Set(["PATCH", "POST", "PUT", "DELETE"]);
@@ -107,7 +107,7 @@ export async function sendProxy(
   }
 
   if (opts.onResponse) {
-    await opts.onResponse(event);
+    await opts.onResponse(event, response);
   }
 
   // Directly send consumed _data

--- a/test/proxy.test.ts
+++ b/test/proxy.test.ts
@@ -347,7 +347,9 @@ describe("", () => {
       app.use(
         "/debug",
         eventHandler(() => {
-          return {};
+          return {
+            foo: "bar",
+          };
         })
       );
     });
@@ -388,6 +390,26 @@ describe("", () => {
       const result = await request.get("/");
 
       expect(result.header["x-custom"]).toEqual("hello");
+    });
+
+    it("allows to get the actual response", async () => {
+      let proxyResponse;
+
+      app.use(
+        "/",
+        eventHandler((event) => {
+          return proxyRequest(event, url + "/debug", {
+            fetch,
+            async onResponse(_event, response) {
+              proxyResponse = await response.json();
+            },
+          });
+        })
+      );
+
+      await request.get("/");
+
+      expect(proxyResponse).toEqual({ foo: "bar" });
     });
   });
 });

--- a/test/proxy.test.ts
+++ b/test/proxy.test.ts
@@ -341,4 +341,53 @@ describe("", () => {
       );
     });
   });
+
+  describe("onResponse", () => {
+    beforeEach(() => {
+      app.use(
+        "/debug",
+        eventHandler(() => {
+          return {};
+        })
+      );
+    });
+
+    it("allows modifying response event", async () => {
+      app.use(
+        "/",
+        eventHandler((event) => {
+          return proxyRequest(event, url + "/debug", {
+            fetch,
+            onResponse(_event) {
+              setHeader(_event, "x-custom", "hello");
+            },
+          });
+        })
+      );
+
+      const result = await request.get("/");
+
+      expect(result.header["x-custom"]).toEqual("hello");
+    });
+
+    it("allows modifying response event async", async () => {
+      app.use(
+        "/",
+        eventHandler((event) => {
+          return proxyRequest(event, url + "/debug", {
+            fetch,
+            onResponse(_event) {
+              return new Promise((resolve) => {
+                resolve(setHeader(_event, "x-custom", "hello"));
+              });
+            },
+          });
+        })
+      );
+
+      const result = await request.get("/");
+
+      expect(result.header["x-custom"]).toEqual("hello");
+    });
+  });
 });


### PR DESCRIPTION
Resolves #354 

This PR adds `onResponse` callback to `sendProxy` and `proxyRequest` utilities.
It accepts proxy `event` as argument which can be used to modify the response headers, cookies etc.:
```ts
return proxyRequest(event, target, {
  onResponse(_event) {
    setHeader(_event, 'foo', 'bar')
  }
})
```
It can also be async:
```ts
return proxyRequest(event, target, {
  async onResponse(_event) {
    // some async stuff
  }
})
```