### PR TITLE
fix: parse rawBody buffer when isBuffer

### DIFF
--- a/src/utils/body.ts
+++ b/src/utils/body.ts
@@ -31,7 +31,7 @@ export function readRawBody<E extends Encoding = "utf8">(
     (event.node.req as any).body; /* unjs/unenv #8 */
   if (_rawBody) {
     const promise = Promise.resolve(
-      Buffer.isBuffer(_rawBody) ? _rawBody : Buffer.from(_rawBody)
+      Buffer.isBuffer(_rawBody) ? Buffer.from(_rawBody) : _rawBody
     );
     return encoding
       ? promise.then((buff) => buff.toString(encoding))


### PR DESCRIPTION
Flip order of operation.

Fixes issue:
```
[request error] [unhandled] [500] The first argument must be of type string or an instance of Buffer, ArrayBuffer, or Array or an Array-like Object. Received an instance of Promise
```