### PR TITLE
feat(useSession): support custom session id generator

### DIFF
--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -28,7 +28,7 @@ export interface SessionConfig {
   seal?: SealOptions;
   crypto?: Crypto;
   /** Default is Crypto.randomUUID */
-  idGenerator?: () => string;
+  generateId?: () => string;
 }
 
 const DEFAULT_NAME = "h3";
@@ -114,7 +114,7 @@ export async function getSession<T extends SessionDataT = SessionDataT>(
   // New session store in response cookies
   if (!session.id) {
     session.id =
-      config.idGenerator?.() ?? (config.crypto || crypto).randomUUID();
+      config.generateId?.() ?? (config.crypto || crypto).randomUUID();
     session.createdAt = Date.now();
     await updateSession(event, config);
   }

--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -27,6 +27,8 @@ export interface SessionConfig {
   sessionHeader?: false | string;
   seal?: SealOptions;
   crypto?: Crypto;
+  /** Default is Crypto.randomUUID */
+  idGenerator?: () => string,
 }
 
 const DEFAULT_NAME = "h3";
@@ -111,7 +113,7 @@ export async function getSession<T extends SessionDataT = SessionDataT>(
 
   // New session store in response cookies
   if (!session.id) {
-    session.id = (config.crypto || crypto).randomUUID();
+    session.id = config.idGenerator?.() ?? (config.crypto || crypto).randomUUID();
     session.createdAt = Date.now();
     await updateSession(event, config);
   }

--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -28,7 +28,7 @@ export interface SessionConfig {
   seal?: SealOptions;
   crypto?: Crypto;
   /** Default is Crypto.randomUUID */
-  idGenerator?: () => string,
+  idGenerator?: () => string;
 }
 
 const DEFAULT_NAME = "h3";
@@ -113,7 +113,8 @@ export async function getSession<T extends SessionDataT = SessionDataT>(
 
   // New session store in response cookies
   if (!session.id) {
-    session.id = config.idGenerator?.() ?? (config.crypto || crypto).randomUUID();
+    session.id =
+      config.idGenerator?.() ?? (config.crypto || crypto).randomUUID();
     session.createdAt = Date.now();
     await updateSession(event, config);
   }


### PR DESCRIPTION
Sometimes it may be necessary to customize the session ID.
for example, using something like `crypto.randomBytes(20).toString('base64url')`.
having a method available in the session configuration would be convenient.