### PR TITLE
fix(types): return type for get router parameter utils

### DIFF
--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -7,7 +7,9 @@ export function getQuery(event: H3Event) {
   return _getQuery(event.node.req.url || "");
 }
 
-export function getRouterParams(event: H3Event): H3Event["context"] {
+export function getRouterParams(
+  event: H3Event
+): NonNullable<H3Event["context"]["params"]> {
   // Fallback object needs to be returned in case router is not used (#149)
   return event.context.params || {};
 }
@@ -15,7 +17,7 @@ export function getRouterParams(event: H3Event): H3Event["context"] {
 export function getRouterParam(
   event: H3Event,
   name: string
-): H3Event["context"][string] {
+): string | undefined {
   const params = getRouterParams(event);
 
   return params[name];


### PR DESCRIPTION
Improve the return type of `getRouterParam` and `getRouterParams`. The latter's return type in particular is misleading especially when destructured:

![image](https://github.com/unjs/h3/assets/6721822/f9c41258-459a-437d-b0dc-cf2c3dcfcc57)

And the implementation is simply returning the `event.context.params` with a fallback.

https://github.com/unjs/h3/blob/3e5f42748ab73102c1b9c2059fe8fa110e734363/src/utils/request.ts#L10-L13

Unless `event.context.params`, for some reason, can possibly have `sessions` and `params` in it?