### PR TITLE
fix(readRawBody): handle body as object

### DIFF
--- a/src/utils/body.ts
+++ b/src/utils/body.ts
@@ -30,9 +30,15 @@ export function readRawBody<E extends Encoding = "utf8">(
     (event.node.req as any)[RawBodySymbol] ||
     (event.node.req as any).body; /* unjs/unenv #8 */
   if (_rawBody) {
-    const promise = Promise.resolve(_rawBody).then((_resolved) =>
-      Buffer.isBuffer(_resolved) ? _resolved : Buffer.from(_resolved)
-    );
+    const promise = Promise.resolve(_rawBody).then((_resolved) => {
+      if (Buffer.isBuffer(_resolved)) {
+        return _resolved;
+      }
+      if (_resolved.constructor === Object) {
+        return Buffer.from(JSON.stringify(_resolved));
+      }
+      return Buffer.from(_resolved);
+    });
     return encoding
       ? promise.then((buff) => buff.toString(encoding))
       : (promise as Promise<any>);

--- a/test/body.test.ts
+++ b/test/body.test.ts
@@ -194,7 +194,7 @@ describe("", () => {
       expect(result.text).toBe("200");
     });
 
-    it("handle readBody with Oject type (unenv)", async () => {
+    it("handle readBody with Object type (unenv)", async () => {
       app.use(
         "/",
         eventHandler(async (event) => {

--- a/test/body.test.ts
+++ b/test/body.test.ts
@@ -194,6 +194,26 @@ describe("", () => {
       expect(result.text).toBe("200");
     });
 
+    it("handle readBody with Oject type (unenv)", async () => {
+      app.use(
+        "/",
+        eventHandler(async (event) => {
+          // Emulate unenv
+          // @ts-ignore
+          event.node.req.body = { test: 1 };
+
+          const body = await readBody(event);
+          expect(body).toMatchObject({ test: 1 });
+
+          return "200";
+        })
+      );
+
+      const result = await request.post("/api/test").send();
+
+      expect(result.text).toBe("200");
+    });
+
     it("handle readRawBody with array buffer type (unenv)", async () => {
       app.use(
         "/",


### PR DESCRIPTION
- Closes #381 
- Related to 19d133d

Based in on [this](https://github.com/unjs/h3/commit/19d133d6a33ffb742713f4d83f00f555aeb83224#r109674536) where seems `unenv` already parsed the `body` to `Object` and when try to create a `Buffer` from it, in `nitro` Firebase preset, throw a error mentioned [here](https://github.com/unjs/h3/issues/381#issuecomment-1568943830)

```
TypeError [ERR_INVALID_ARG_TYPE]: The first argument must be of type string or an instance of Buffer, ArrayBuffer, or Array or an Array-like Object. Received an instance of Object
```

This change check if `body` is a `Object` and converts to string before create a Buffer from it