### PR TITLE
fix(proxy): split cookie headers properly with native node fetch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,15 @@ on:
 jobs:
   ci:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [16, 18, 20]
     steps:
       - uses: actions/checkout@v3
       - run: corepack enable
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: ${{ matrix.node }}
           cache: "pnpm"
       - run: pnpm install
       - run: pnpm lint


### PR DESCRIPTION
Proxy on Node.js >= 18, uses native `fetch` (which already splits `set-cookie` headers). Because of this, we need to merge/split all cookie headers and set it once otherwise (currently) only first cookie(s) will be added.