### PR TITLE
fix(router): send 204 with empty string in preemptive mode instead of 404

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -143,7 +143,7 @@ export function createAppEventHandler(stack: Stack, options: AppOptions) {
     if (!event.node.res.writableEnded) {
       throw createError({
         statusCode: 404,
-        statusMessage: `Cannot find any route matching ${
+        statusMessage: `Cannot find any path matching ${
           event.node.req.url || "/"
         }.`,
       });

--- a/src/router.ts
+++ b/src/router.ts
@@ -2,6 +2,7 @@ import { createRouter as _createRouter } from "radix3";
 import type { HTTPMethod, EventHandler } from "./types";
 import { createError } from "./error";
 import { eventHandler, toEventHandler } from "./event";
+import { setResponseStatus } from "./utils";
 
 export type RouterMethod = Lowercase<HTTPMethod>;
 const RouterMethods: RouterMethod[] = [
@@ -121,6 +122,7 @@ export function createRouter(opts: CreateRouterOptions = {}): Router {
     // Call handler
     return Promise.resolve(handler(event)).then((res) => {
       if (res === undefined && (opts.preemptive || opts.preemtive)) {
+        setResponseStatus(event, 204);
         return "";
       }
       return res;

--- a/src/router.ts
+++ b/src/router.ts
@@ -103,11 +103,15 @@ export function createRouter(opts: CreateRouterOptions = {}): Router {
     ).toLowerCase() as RouterMethod;
     const handler = matched.handlers[method] || matched.handlers.all;
     if (!handler) {
-      throw createError({
-        statusCode: 405,
-        name: "Method Not Allowed",
-        statusMessage: `Method ${method} is not allowed on this route.`,
-      });
+      if (opts.preemptive || opts.preemtive) {
+        throw createError({
+          statusCode: 405,
+          name: "Method Not Allowed",
+          statusMessage: `Method ${method} is not allowed on this route.`,
+        });
+      } else {
+        return; // Let app match other handlers
+      }
     }
 
     // Add params

--- a/src/router.ts
+++ b/src/router.ts
@@ -119,7 +119,12 @@ export function createRouter(opts: CreateRouterOptions = {}): Router {
     event.context.params = params;
 
     // Call handler
-    return handler(event);
+    return Promise.resolve(handler(event)).then((res) => {
+      if (res === undefined && (opts.preemptive || opts.preemtive)) {
+        return "";
+      }
+      return res;
+    });
   });
 
   return router;

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -97,10 +97,49 @@ describe("router", () => {
     const res = await request.get("/404");
     expect(res.status).toEqual(404);
   });
+});
+
+describe("router (preemptive)", () => {
+  let app: App;
+  let router: Router;
+  let request: SuperTest<Test>;
+
+  beforeEach(() => {
+    app = createApp({ debug: false });
+    router = createRouter({ preemptive: true })
+      .get(
+        "/test",
+        eventHandler(() => "Test")
+      )
+      .get(
+        "/undefined",
+        eventHandler(() => undefined)
+      );
+    app.use(router);
+    request = supertest(toNodeListener(app));
+  });
+
+  it("Handle /test", async () => {
+    const res = await request.get("/test");
+    expect(res.text).toEqual("Test");
+  });
+
+  it("Handle /404", async () => {
+    const res = await request.get("/404");
+    expect(JSON.parse(res.text)).toMatchObject({
+      statusCode: 404,
+      statusMessage: "Cannot find any route matching /404.",
+    });
+  });
 
   it("Not matching route method", async () => {
     const res = await request.head("/test");
     expect(res.status).toEqual(405);
+  });
+
+  it("Handle /undefined", async () => {
+    const res = await request.get("/undefined");
+    expect(res.text).toEqual("");
   });
 });
 


### PR DESCRIPTION
Resolves #407. When `preemptive` router flag is enabled and an event handler is returning nothing, instead of showing a 404, we response empty string with 204 No Content gracefully.

This PR also makes slight fixes:
 - Use `path` instead of `route` in error message of default app to distinguish errors
 - Respect `preemptive` flag for when a route METHOD is not matching.

Note: For nitro, we need to enable flag to make this change effective.