### PR TITLE
feat: support `event.handled` flag

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -111,7 +111,7 @@ export function createAppEventHandler(stack: Stack, options: AppOptions) {
         continue;
       }
       const val = await layer.handler(event);
-      if (event.node.res.writableEnded) {
+      if (event.handled) {
         return;
       }
       const type = typeof val;
@@ -140,7 +140,7 @@ export function createAppEventHandler(stack: Stack, options: AppOptions) {
         }
       }
     }
-    if (!event.node.res.writableEnded) {
+    if (!event.handled) {
       throw createError({
         statusCode: 404,
         statusMessage: `Cannot find any path matching ${

--- a/src/error.ts
+++ b/src/error.ts
@@ -133,7 +133,7 @@ export function sendError(
   error: Error | H3Error,
   debug?: boolean
 ) {
-  if (event.node.res.writableEnded) {
+  if (event.handled) {
     return;
   }
 
@@ -150,7 +150,7 @@ export function sendError(
     responseBody.stack = (h3Error.stack || "").split("\n").map((l) => l.trim());
   }
 
-  if (event.node.res.writableEnded) {
+  if (event.handled) {
     return;
   }
   const _code = Number.parseInt(h3Error.statusCode as unknown as string);


### PR DESCRIPTION
Currently, we were directly depending on node `writableEnded` flag to determine if a response is ended or not. Sometimes user wants to takeover. By introducing more standard `event.handled` flag we can support it (first step will be possible with internal/experimental `_handled` flag when needed) 