### PR TITLE
fix(cache, proxy, response): avoid sending handled events

### DIFF
--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -44,7 +44,9 @@ export function handleCacheHeaders(
 
   if (cacheMatched) {
     event.node.res.statusCode = 304;
-    event.node.res.end();
+    if (!event.handled) {
+      event.node.res.end();
+    }
     return true;
   }
 

--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -122,6 +122,11 @@ export async function sendProxy(
     return (response as any)._data;
   }
 
+  // Ensure event is not handled
+  if (event.handled) {
+    return;
+  }
+
   // Send at once
   if (opts.sendStream === false) {
     const data = new Uint8Array(await response.arrayBuffer());

--- a/src/utils/response.ts
+++ b/src/utils/response.ts
@@ -14,7 +14,9 @@ export function send(event: H3Event, data?: any, type?: string): Promise<void> {
   }
   return new Promise((resolve) => {
     defer(() => {
-      event.node.res.end(data);
+      if (!event.handled) {
+        event.node.res.end(data);
+      }
       resolve();
     });
   });
@@ -33,7 +35,9 @@ export function sendNoContent(event: H3Event, code = 204) {
   if (event.node.res.statusCode === 204) {
     event.node.res.removeHeader("content-length");
   }
-  event.node.res.end();
+  if (!event.handled) {
+    event.node.res.end();
+  }
 }
 
 export function setResponseStatus(


### PR DESCRIPTION
When event is handled, utils should early return and avoid calling `node.res.end`