### PR TITLE
fix(fetchWithEvent): allow customizing fetch impl type

### DIFF
--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -151,7 +151,9 @@ export function getProxyRequestHeaders(event: H3Event) {
   return headers;
 }
 
-export function fetchWithEvent<T extends (req: RequestInfo | URL, opts?: any) => any = typeof fetch>(
+export function fetchWithEvent<
+  T extends (req: RequestInfo | URL, opts?: any) => any = typeof fetch
+>(
   event: H3Event,
   req: RequestInfo | URL,
   init?: RequestInit & { context?: H3EventContext },

--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -151,12 +151,12 @@ export function getProxyRequestHeaders(event: H3Event) {
   return headers;
 }
 
-export function fetchWithEvent(
+export function fetchWithEvent<T extends (req: RequestInfo | URL, opts?: any) => any = typeof fetch>(
   event: H3Event,
   req: RequestInfo | URL,
   init?: RequestInit & { context?: H3EventContext },
-  options?: { fetch: typeof fetch }
-) {
+  options?: { fetch: T }
+): ReturnType<T> {
   return _getFetch(options?.fetch)(req, <RequestInit>{
     ...init,
     context: init?.context || event.context,
@@ -169,7 +169,7 @@ export function fetchWithEvent(
 
 // -- internal utils --
 
-function _getFetch(_fetch?: typeof fetch) {
+function _getFetch<T = typeof fetch>(_fetch?: T) {
   if (_fetch) {
     return _fetch;
   }

--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -152,13 +152,15 @@ export function getProxyRequestHeaders(event: H3Event) {
 }
 
 export function fetchWithEvent<
-  T extends (req: RequestInfo | URL, opts?: any) => any = typeof fetch
+  T = unknown,
+  _R = any,
+  F extends (req: RequestInfo | URL, opts?: any) => any = typeof fetch
 >(
   event: H3Event,
   req: RequestInfo | URL,
   init?: RequestInit & { context?: H3EventContext },
-  options?: { fetch: T }
-): ReturnType<T> {
+  options?: { fetch: F }
+): unknown extends T ? ReturnType<F> : T {
   return _getFetch(options?.fetch)(req, <RequestInit>{
     ...init,
     context: init?.context || event.context,


### PR DESCRIPTION
Downstream we are wrongly typing `event.$fetch`. This is part of the fix.