### PR TITLE
feat: add runtime typesafe body and query parameters helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,11 +168,13 @@ H3 has a concept of composable utilities that accept `event` (from `eventHandler
 
 - `readRawBody(event, encoding?)`
 - `readBody(event)`
+- `readBodySafe(event, schema, onError?)`
 - `readMultipartFormData(event)`
 
 #### Request
 
 - `getQuery(event)`
+- `getQuerySafe(event, schema, onError?)`
 - `getRouterParams(event)`
 - `getMethod(event, default?)`
 - `isMethod(event, expected, allowHead?)`

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "test": "pnpm lint && vitest run --coverage"
   },
   "dependencies": {
+    "@decs/typeschema": "^0.5.2",
     "cookie-es": "^1.0.0",
     "defu": "^6.1.2",
     "destr": "^2.0.0",
@@ -58,7 +59,8 @@
     "supertest": "^6.3.3",
     "typescript": "^5.1.6",
     "unbuild": "^1.2.1",
-    "vitest": "^0.33.0"
+    "vitest": "^0.33.0",
+    "zod": "^3.21.4"
   },
   "packageManager": "pnpm@8.6.9"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@decs/typeschema':
+        specifier: ^0.5.2
+        version: 0.5.2(zod@3.21.4)
       cookie-es:
         specifier: ^1.0.0
         version: 1.0.0
@@ -90,6 +93,9 @@ importers:
       vitest:
         specifier: ^0.33.0
         version: 0.33.0
+      zod:
+        specifier: ^3.21.4
+        version: 3.21.4
 
   playground:
     dependencies:
@@ -313,6 +319,13 @@ packages:
       '@babel/types': 7.22.5
     dev: true
 
+  /@babel/runtime@7.22.6:
+    resolution: {integrity: sha512-wDb5pWm4WDdF6LFUde3Jl8WzPA+3ZbxYqkC6xAXuD3irdEHN1k0NfTRrJD8ZD378SJ61miMLCqIOXYhd8x+AJQ==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      regenerator-runtime: 0.13.11
+    dev: false
+
   /@babel/standalone@7.22.9:
     resolution: {integrity: sha512-RRUFpN2WiHaczMqIhmy7VoruvSw+c3NSq6BczondQ6elJXtKzr9cAWWsWWZvtZ/rYFQpoQlch5VxQe4aWTt8LA==}
     engines: {node: '>=6.9.0'}
@@ -364,6 +377,45 @@ packages:
     requiresBuild: true
     dev: true
     optional: true
+
+  /@decs/typeschema@0.5.2(zod@3.21.4):
+    resolution: {integrity: sha512-ug0gf9AWM/XNFwqUiwOgC15u1R2mgqV8A2Xs4Pm01VsRB/T+JNMu/P5k4XYR1moi/lTJ6G9w0hgBcRxh8YHp/A==}
+    peerDependencies:
+      '@sinclair/typebox': ^0.29.4
+      ajv: ^8.12.0
+      arktype: ^1.0.14-alpha
+      fp-ts: ^2.16.0
+      io-ts: ^2.2.20
+      joi: ^17.9.2
+      runtypes: ^6.7.0
+      superstruct: ^1.0.3
+      yup: ^1.2.0
+      zod: ^3.21.4
+    peerDependenciesMeta:
+      '@sinclair/typebox':
+        optional: true
+      ajv:
+        optional: true
+      arktype:
+        optional: true
+      fp-ts:
+        optional: true
+      io-ts:
+        optional: true
+      joi:
+        optional: true
+      runtypes:
+        optional: true
+      superstruct:
+        optional: true
+      yup:
+        optional: true
+      zod:
+        optional: true
+    dependencies:
+      json-schema-to-ts: 2.9.1
+      zod: 3.21.4
+    dev: false
 
   /@esbuild/android-arm64@0.17.19:
     resolution: {integrity: sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA==}
@@ -1051,7 +1103,6 @@ packages:
 
   /@types/json-schema@7.0.12:
     resolution: {integrity: sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==}
-    dev: true
 
   /@types/json5@0.0.29:
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
@@ -4115,6 +4166,15 @@ packages:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
     dev: true
 
+  /json-schema-to-ts@2.9.1:
+    resolution: {integrity: sha512-8MNpRGERlCUWYeJwsWkMrJ0MWzBz49dfqpG+n9viiIlP4othaahbiaNQZuBzmPxRLUhOv1QJMCzW5WE8nHFGIQ==}
+    engines: {node: '>=16'}
+    dependencies:
+      '@babel/runtime': 7.22.6
+      '@types/json-schema': 7.0.12
+      ts-algebra: 1.2.0
+    dev: false
+
   /json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
     dev: true
@@ -5135,6 +5195,10 @@ packages:
       picomatch: 2.3.1
     dev: true
 
+  /regenerator-runtime@0.13.11:
+    resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==}
+    dev: false
+
   /regexp-tree@0.1.27:
     resolution: {integrity: sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==}
     hasBin: true
@@ -5794,6 +5858,10 @@ packages:
       nanobench: 2.1.1
     dev: true
 
+  /ts-algebra@1.2.0:
+    resolution: {integrity: sha512-kMuJJd8B2N/swCvIvn1hIFcIOrLGbWl9m/J6O3kHx9VRaevh00nvgjPiEGaRee7DRaAczMYR2uwWvXU22VFltw==}
+    dev: false
+
   /tsconfig-paths@3.14.2:
     resolution: {integrity: sha512-o/9iXgCYc5L/JxCHPe3Hvh8Q/2xm5Z+p18PESBU6Ff33695QnCHBEjcytY2q19ua7Mbl/DavtBOLq+oG0RCL+g==}
     dependencies:
@@ -6290,3 +6358,6 @@ packages:
     resolution: {integrity: sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==}
     engines: {node: '>=12.20'}
     dev: true
+
+  /zod@3.21.4:
+    resolution: {integrity: sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==}

--- a/src/utils/internal/validation.ts
+++ b/src/utils/internal/validation.ts
@@ -9,6 +9,7 @@ export const assertSchema = async <T>(
   onError?: (err: any) => any
 ) => {
   try {
+    // @todo use AggregateError to throw all validation errors https://github.com/decs/typeschema/issues/8
     return await assert(schema, payload);
   } catch (error) {
     if (onError) {

--- a/src/utils/internal/validation.ts
+++ b/src/utils/internal/validation.ts
@@ -1,6 +1,6 @@
 import type { Schema } from "@decs/typeschema";
 import { assert } from "@decs/typeschema";
-import { createError } from "src/error";
+import { createError } from "../../error";
 export type { Infer, Schema } from "@decs/typeschema";
 
 export const assertSchema = async <T>(

--- a/src/utils/internal/validation.ts
+++ b/src/utils/internal/validation.ts
@@ -1,0 +1,19 @@
+import type { Schema } from "@decs/typeschema";
+import { assert } from "@decs/typeschema";
+import { createError } from "src/error";
+export type { Infer, Schema } from "@decs/typeschema";
+
+export const assertSchema = async <T>(
+  schema: Schema,
+  payload: T,
+  onError?: (err: any) => any
+) => {
+  try {
+    return await assert(schema, payload);
+  } catch (error) {
+    if (onError) {
+      return onError(error);
+    }
+    throw createError({ statusCode: 500, statusMessage: "Assertion Error." });
+  }
+};

--- a/test/validation.test.ts
+++ b/test/validation.test.ts
@@ -51,32 +51,39 @@ describe("", () => {
     });
   });
 
+  const below18 = Number.parseInt(process.version.slice(1).split(".")[0]) < 18;
   describe("body validation", () => {
-    it("can parse and return safe x-www-form-urlencoded data", async () => {
-      app.use(
-        "/",
-        eventHandler(async (event) => {
-          const schema = z.object({
-            firstName: z.string(),
-            lastName: z.string(),
-          });
-          const data = await readBodySafe(event, schema);
-          expectTypeOf(data).toMatchTypeOf<{
-            firstName: string;
-            lastName: string;
-          }>();
-          return { ...data };
-        })
-      );
+    it.skipIf(below18)(
+      "can parse and return safe x-www-form-urlencoded data",
+      async () => {
+        app.use(
+          "/",
+          eventHandler(async (event) => {
+            const schema = z.object({
+              firstName: z.string(),
+              lastName: z.string(),
+            });
+            const data = await readBodySafe(event, schema);
+            expectTypeOf(data).toMatchTypeOf<{
+              firstName: string;
+              lastName: string;
+            }>();
+            return { ...data };
+          })
+        );
 
-      const result = await request
-        .post("/api/test")
-        .set("content-type", "application/x-www-form-urlencoded")
-        .send("firstName=John&lastName=Doe");
+        const result = await request
+          .post("/api/test")
+          .set("content-type", "application/x-www-form-urlencoded")
+          .send("firstName=John&lastName=Doe");
 
-      expect(result.status).toBe(200);
-      expect(result.body).toMatchObject({ firstName: "John", lastName: "Doe" });
-    });
+        expect(result.status).toBe(200);
+        expect(result.body).toMatchObject({
+          firstName: "John",
+          lastName: "Doe",
+        });
+      }
+    );
 
     it("can parse and return safe json data", async () => {
       app.use(
@@ -107,7 +114,7 @@ describe("", () => {
       });
     });
 
-    it("can throw an error on schema mismatch", async () => {
+    it.skipIf(below18)("can throw an error on schema mismatch", async () => {
       app.use(
         "/",
         eventHandler(async (event) => {
@@ -129,37 +136,40 @@ describe("", () => {
       expect(result.body).toMatchObject({ statusCode: 500 });
     });
 
-    it("can throw a custom error when assertion fails", async () => {
-      app.use(
-        "/",
-        eventHandler(async (event) => {
-          const schema = z.object({
-            firstName: z.string(),
-            lastName: z.number(),
-          });
-          const data = await readBodySafe(event, schema, () => {
-            throw createError({
-              statusMessage: "Invalid data",
-              statusCode: 400,
+    it.skipIf(below18)(
+      "can throw a custom error when assertion fails",
+      async () => {
+        app.use(
+          "/",
+          eventHandler(async (event) => {
+            const schema = z.object({
+              firstName: z.string(),
+              lastName: z.number(),
             });
-          });
-          return { ...data };
-        })
-      );
+            const data = await readBodySafe(event, schema, () => {
+              throw createError({
+                statusMessage: "Invalid data",
+                statusCode: 400,
+              });
+            });
+            return { ...data };
+          })
+        );
 
-      const result = await request
-        .post("/api/test")
-        .set("content-type", "application/x-www-form-urlencoded")
-        .send("firstName=John&lastName=Doe");
+        const result = await request
+          .post("/api/test")
+          .set("content-type", "application/x-www-form-urlencoded")
+          .send("firstName=John&lastName=Doe");
 
-      expect(result.status).toBe(400);
-      expect(result.body).toMatchObject({
-        statusMessage: "Invalid data",
-        statusCode: 400,
-      });
-    });
+        expect(result.status).toBe(400);
+        expect(result.body).toMatchObject({
+          statusMessage: "Invalid data",
+          statusCode: 400,
+        });
+      }
+    );
 
-    it("can throw with a custom validator schema", async () => {
+    it.skipIf(below18)("can throw with a custom validator schema", async () => {
       app.use(
         "/",
         eventHandler(async (event) => {

--- a/test/validation.test.ts
+++ b/test/validation.test.ts
@@ -1,0 +1,193 @@
+import supertest, { SuperTest, Test } from "supertest";
+import { describe, it, expect, expectTypeOf, beforeEach } from "vitest";
+import { z } from "zod";
+import {
+  createApp,
+  toNodeListener,
+  App,
+  eventHandler,
+  readBodySafe,
+  createError,
+  getQuerySafe,
+} from "../src";
+
+describe("", () => {
+  let app: App;
+  let request: SuperTest<Test>;
+
+  beforeEach(() => {
+    app = createApp({ debug: true });
+    request = supertest(toNodeListener(app));
+  });
+
+  describe("query validation", () => {
+    it("can parse and return safe query params", async () => {
+      app.use(
+        "/",
+        eventHandler(async (event) => {
+          const schema = z.object({
+            bool: z.string(),
+            name: z.string(),
+            number: z.string(),
+          });
+          const query = await getQuerySafe(event, schema);
+          expectTypeOf(query).toMatchTypeOf<{
+            bool: string;
+            name: string;
+            number: string;
+          }>();
+          return query;
+        })
+      );
+      const result = await request.get(
+        "/api/test?bool=true&name=string&number=1"
+      );
+      expect(result.statusCode).toBe(200);
+      expect(result.body).toMatchObject({
+        bool: "true",
+        name: "string",
+        number: "1",
+      });
+    });
+  });
+
+  describe("body validation", () => {
+    it("can parse and return safe x-www-form-urlencoded data", async () => {
+      app.use(
+        "/",
+        eventHandler(async (event) => {
+          const schema = z.object({
+            firstName: z.string(),
+            lastName: z.string(),
+          });
+          const data = await readBodySafe(event, schema);
+          expectTypeOf(data).toMatchTypeOf<{
+            firstName: string;
+            lastName: string;
+          }>();
+          return { ...data };
+        })
+      );
+
+      const result = await request
+        .post("/api/test")
+        .set("content-type", "application/x-www-form-urlencoded")
+        .send("firstName=John&lastName=Doe");
+
+      expect(result.status).toBe(200);
+      expect(result.body).toMatchObject({ firstName: "John", lastName: "Doe" });
+    });
+
+    it("can parse and return safe json data", async () => {
+      app.use(
+        "/",
+        eventHandler(async (event) => {
+          const schema = z.object({
+            firstName: z.string(),
+            lastName: z.string(),
+          });
+          const data = await readBodySafe(event, schema);
+          expectTypeOf(data).toMatchTypeOf<{
+            firstName: string;
+            lastName: string;
+          }>();
+          return { ...data };
+        })
+      );
+
+      const result = await request
+        .post("/api/test")
+        .set("content-type", "application/json")
+        .send({ firstName: "John", lastName: "Doe", age: 30 });
+
+      expect(result.status).toBe(200);
+      expect(result.body).toMatchObject({
+        firstName: "John",
+        lastName: "Doe",
+      });
+    });
+
+    it("can throw an error on schema mismatch", async () => {
+      app.use(
+        "/",
+        eventHandler(async (event) => {
+          const schema = z.object({
+            firstName: z.string(),
+            lastName: z.number(),
+          });
+          const data = await readBodySafe(event, schema);
+          return { ...data };
+        })
+      );
+
+      const result = await request
+        .post("/api/test")
+        .set("content-type", "application/x-www-form-urlencoded")
+        .send("firstName=John&lastName=Doe");
+
+      expect(result.status).toBe(500);
+      expect(result.body).toMatchObject({ statusCode: 500 });
+    });
+
+    it("can throw a custom error when assertion fails", async () => {
+      app.use(
+        "/",
+        eventHandler(async (event) => {
+          const schema = z.object({
+            firstName: z.string(),
+            lastName: z.number(),
+          });
+          const data = await readBodySafe(event, schema, () => {
+            throw createError({
+              statusMessage: "Invalid data",
+              statusCode: 400,
+            });
+          });
+          return { ...data };
+        })
+      );
+
+      const result = await request
+        .post("/api/test")
+        .set("content-type", "application/x-www-form-urlencoded")
+        .send("firstName=John&lastName=Doe");
+
+      expect(result.status).toBe(400);
+      expect(result.body).toMatchObject({
+        statusMessage: "Invalid data",
+        statusCode: 400,
+      });
+    });
+
+    it("can throw with a custom validator schema", async () => {
+      app.use(
+        "/",
+        eventHandler(async (event) => {
+          const data = await readBodySafe(event, (body) => {
+            if (
+              body &&
+              typeof body === "object" &&
+              "firstName" in body &&
+              "lastName" in body &&
+              "age" in body
+            ) {
+              return body;
+            }
+            throw new TypeError("Custom Error");
+          });
+          return data;
+        })
+      );
+
+      const result = await request
+        .post("/api/test")
+        .set("content-type", "application/x-www-form-urlencoded")
+        .send("firstName=John&lastName=Doe");
+
+      expect(result.status).toBe(500);
+      expect(result.body).toMatchObject({
+        statusCode: 500,
+      });
+    });
+  });
+});


### PR DESCRIPTION
- feat: add formdata and request helpers
- chore: rename to eventToRequest and readFormData
- feat: add readBodySafe and getQuerySafe helpers

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
Resolves #419
Resolves #402 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

(This PR includes https://github.com/unjs/h3/pull/421)

This PR ads two new helpers to H3 

- readBodySafe
- getQuerySafe

Both of these helpers accept a https://github.com/decs/typeschema schema as the 2nd argument, which is compatible with zod, yup, joi, superstruct, typia, runtypes, arktype and custom validation function.
`readBodySafe` implementation will use FormData for `x-www-form-urlencoded`, and then rely on `safeDestr` for body parsing before passing it to the schema validation. By design, both these function will throw on runtime validation errors.

It would also be possible to take https://github.com/decs/typeschema and extract its logic into our own internal helpers or UnJS, as it's a very tiny and clever library (50 LOC). We could also look into creating a unjs version of this library that fits our needs in the future.

I'm looking for feedback for alternative APIs.

### 📚 Usage

Here's an example with a zod schema.

```ts
  eventHandler(async (event) => {
    const schema = z.object({
      firstName: z.string(),
      lastName: z.string(),
    });
    const data = await readBodySafe(event, schema);
    expectTypeOf(data).toMatchTypeOf<{
      firstName: string;
      lastName: string;
    }>();
    return { ...data };
  })
```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
