### PR TITLE
feat: support web streams

### DIFF
--- a/src/utils/response.ts
+++ b/src/utils/response.ts
@@ -178,6 +178,7 @@ export function sendStream(
   // Early return if response Socket is not available for worker environments (unjs/nitro)
   if (!event.node.res.socket) {
     event._handled = true;
+    // TODO: Hook and handle stream errors
     return Promise.resolve();
   }
 
@@ -192,7 +193,6 @@ export function sendStream(
         })
       )
       .then(() => {
-        event._handled = true;
         event.node.res.end();
       });
   }

--- a/src/utils/response.ts
+++ b/src/utils/response.ts
@@ -1,7 +1,6 @@
 import type { OutgoingMessage } from "node:http";
 import type { Readable } from "node:stream";
 import type { Socket } from "node:net";
-import { createError, sendError } from "../error";
 import type { H3Event } from "../event";
 import { MIMES } from "./consts";
 import { sanitizeStatusCode, sanitizeStatusMessage } from "./sanitize";

--- a/src/utils/response.ts
+++ b/src/utils/response.ts
@@ -1,4 +1,5 @@
 import type { OutgoingMessage } from "node:http";
+import type { Readable } from "node:stream";
 import type { Socket } from "node:net";
 import { createError } from "../error";
 import type { H3Event } from "../event";
@@ -147,21 +148,66 @@ export function appendResponseHeader(
 
 export const appendHeader = appendResponseHeader;
 
-export function isStream(data: any) {
-  return (
-    data &&
-    typeof data === "object" &&
-    typeof data.pipe === "function" &&
-    typeof data.on === "function"
-  );
+export function isStream(data: any): data is Readable | ReadableStream {
+  if (!data || typeof data !== "object") {
+    return false;
+  }
+  // Node.js Readable Streams
+  if (typeof data.pipe === "function" && typeof data.on === "function") {
+    return true;
+  }
+  // Web Streams
+  if (typeof data.pipeTo === "function") {
+    return true;
+  }
+  return false;
 }
 
-export function sendStream(event: H3Event, data: any): Promise<void> {
-  return new Promise((resolve, reject) => {
-    data.pipe(event.node.res);
-    data.on("end", () => resolve());
-    data.on("error", (error: Error) => reject(createError(error)));
-  });
+export function sendStream(
+  event: H3Event,
+  stream: Readable | ReadableStream
+): Promise<void> {
+  // Validate input
+  if (!stream || typeof stream !== "object") {
+    throw new Error("[h3] Invalid stream provided.");
+  }
+
+  // Directly expose stream for worker environments (unjs/unenv)
+  (event.node.res as unknown as { _data: BodyInit })._data = stream as BodyInit;
+
+  // Early return if response Socket is not available for worker environments (unjs/nitro)
+  if (!event.node.res.socket) {
+    event._handled = true;
+    return Promise.resolve();
+  }
+
+  // Native Web Streams
+  if ("pipeTo" in stream) {
+    event._handled = true;
+    return stream.pipeTo(
+      new WritableStream({
+        write(chunk) {
+          event.node.res.write(chunk);
+        },
+        close() {
+          event.node.res.end();
+        },
+      })
+    );
+  }
+
+  // Node.js Readable streams
+  // https://nodejs.org/api/stream.html#readable-streams
+  if ("pipe" in stream) {
+    event._handled = true;
+    return new Promise<void>((resolve, reject) => {
+      stream.pipe(event.node.res);
+      stream.on("end", () => resolve());
+      stream.on("error", (error: Error) => reject(createError(error)));
+    });
+  }
+
+  throw new Error("[h3] Invalid or incompatible stream provided.");
 }
 
 const noop = () => {};

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -102,7 +102,7 @@ describe("app", () => {
     expect(JSON.parse(res.text).statusMessage).toBe("test");
   });
 
-  it("Web Stream", async () => {
+  it.skipIf(typeof ReadableStream === undefined)("Web Stream", async () => {
     app.use(
       eventHandler(() => {
         return new ReadableStream({
@@ -120,24 +120,27 @@ describe("app", () => {
     expect(res.header["transfer-encoding"]).toBe("chunked");
   });
 
-  it("Web Stream with Error", async () => {
-    app.use(
-      eventHandler(() => {
-        return new ReadableStream({
-          start() {
-            throw createError({
-              statusCode: 500,
-              statusText: "test",
-            });
-          },
-        });
-      })
-    );
-    const res = await request.get("/");
+  it.skipIf(typeof ReadableStream === undefined)(
+    "Web Stream with Error",
+    async () => {
+      app.use(
+        eventHandler(() => {
+          return new ReadableStream({
+            start() {
+              throw createError({
+                statusCode: 500,
+                statusText: "test",
+              });
+            },
+          });
+        })
+      );
+      const res = await request.get("/");
 
-    expect(res.statusCode).toBe(500);
-    expect(JSON.parse(res.text).statusMessage).toBe("test");
-  });
+      expect(res.statusCode).toBe(500);
+      expect(JSON.parse(res.text).statusMessage).toBe("test");
+    }
+  );
 
   it("can return HTML directly", async () => {
     app.use(eventHandler(() => "<h1>Hello world!</h1>"));

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -7,6 +7,7 @@ import {
   App,
   eventHandler,
   fromNodeMiddleware,
+  createError,
 } from "../src";
 
 describe("app", () => {
@@ -58,12 +59,15 @@ describe("app", () => {
     expect(res.text).toBe("<h1>Hello world!</h1>");
   });
 
-  it.todo("can return Readable stream directly", async () => {
+  it("Node.js Readable", async () => {
     app.use(
       eventHandler(() => {
-        const readable = new Readable();
-        readable.push(Buffer.from("<h1>Hello world!</h1>", "utf8"));
-        return readable;
+        return new Readable({
+          read() {
+            this.push(Buffer.from("<h1>Hello world!</h1>", "utf8"));
+            this.push(null);
+          },
+        });
       })
     );
     const res = await request.get("/");
@@ -72,23 +76,30 @@ describe("app", () => {
     expect(res.header["transfer-encoding"]).toBe("chunked");
   });
 
-  it.todo("can return Readable stream that may throw", async () => {
+  it("Node.js Readable with Error", async () => {
     app.use(
       eventHandler(() => {
-        const readable = new Readable();
-        const willThrow = new Transform({
-          transform(_chunk, _encoding, callback) {
-            setTimeout(() => callback(new Error("test")), 0);
+        return new Readable({
+          read() {
+            this.push(Buffer.from("123", "utf8"));
+            this.push(null);
           },
-        });
-        readable.push(Buffer.from("<h1>Hello world!</h1>", "utf8"));
-
-        return readable.pipe(willThrow);
+        }).pipe(
+          new Transform({
+            transform(_chunk, _encoding, callback) {
+              const err = createError({
+                statusCode: 500,
+                statusText: "test",
+              });
+              setTimeout(() => callback(err), 0);
+            },
+          })
+        );
       })
     );
     const res = await request.get("/");
-
-    expect(res.status).toBe(500);
+    expect(res.statusCode).toBe(500);
+    expect(JSON.parse(res.text).statusMessage).toBe("test");
   });
 
   it("can return HTML directly", async () => {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

[<!-- Please ensure there is an open issue and mention its number as #123 -->](https://github.com/unjs/nitro/issues/1327)

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR adds support for sending Web Streams for Node.js and for Worker environments (only via unenv+nitro). Also enables tests.

Users can directly return a web stream in an event handler.

Notes:
- Support for workers is experimental
- Node.js 18 is required for global `ReadableStream` (Node.js 16 does not support Web Streams)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
