### PR TITLE
refactor(app:): split return type conditions

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -110,34 +110,51 @@ export function createAppEventHandler(stack: Stack, options: AppOptions) {
       if (layer.match && !layer.match(event.node.req.url as string, event)) {
         continue;
       }
+
       const val = await layer.handler(event);
+
+      // Already handled
       if (event.handled) {
         return;
       }
-      const type = typeof val;
-      if (type === "string") {
-        return send(event, val, MIMES.html);
-      } else if (isStream(val)) {
-        return sendStream(event, val);
-      } else if (val === null) {
+
+      // Empty Content
+      if (val === null) {
         event.node.res.statusCode = 204;
         return send(event);
-      } else if (
-        type === "object" ||
-        type === "boolean" ||
-        type === "number" /* IS_JSON */
-      ) {
+      }
+
+      if (val) {
+        // Stream
+        if (isStream(val)) {
+          return sendStream(event, val);
+        }
+
+        // Buffer
         if (val.buffer) {
           return send(event, val);
-        } else if (val instanceof Error) {
-          throw createError(val);
-        } else {
-          return send(
-            event,
-            JSON.stringify(val, undefined, spacing),
-            MIMES.json
-          );
         }
+
+        // Error
+        if (val instanceof Error) {
+          throw createError(val);
+        }
+      }
+
+      const valType = typeof val;
+
+      // HTML String
+      if (valType === "string") {
+        return send(event, val, MIMES.html);
+      }
+
+      // JSON Response
+      if (
+        valType === "object" ||
+        valType === "boolean" ||
+        valType === "number"
+      ) {
+        return send(event, JSON.stringify(val, undefined, spacing), MIMES.json);
       }
     }
     if (!event.handled) {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This is a minor refactor to improve app's return type handler to split if conditions. While working on several PRs, it was hard to maintained.

New refactor is also safer against edge conditions by making sure val is not falsy.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
