### PR TITLE
fix(proxy): respect `fetchOptions.method` over incoming request method

### DIFF
--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -31,7 +31,7 @@ export async function proxyRequest(
   opts: ProxyOptions = {}
 ) {
   // Method
-  const method = getMethod(event);
+  const method = opts.fetchOptions?.method ?? getMethod(event);
 
   // Body
   let body;

--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -31,7 +31,7 @@ export async function proxyRequest(
   opts: ProxyOptions = {}
 ) {
   // Method
-  const method = opts.fetchOptions?.method ?? getMethod(event);
+  const method = opts.fetchOptions?.method || getMethod(event);
 
   // Body
   let body;


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
When `proxyRequest` is used with different `method` (e.g. GET) defined in `fetchOptions`, the `body` is still filled and returns `Request with GET/HEAD method cannot have body.`

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
