### PR TITLE
fix: infer return type of lazy event handlers

### DIFF
--- a/src/event/utils.ts
+++ b/src/event/utils.ts
@@ -47,9 +47,9 @@ export function dynamicEventHandler(
   return wrapper;
 }
 
-export function defineLazyEventHandler(
-  factory: LazyEventHandler
-): EventHandler {
+export function defineLazyEventHandler<T extends LazyEventHandler>(
+  factory: T
+): Awaited<ReturnType<T>> {
   let _promise: Promise<EventHandler>;
   let _resolved: EventHandler;
   const resolveHandler = () => {
@@ -76,6 +76,6 @@ export function defineLazyEventHandler(
       return _resolved(event);
     }
     return resolveHandler().then((handler) => handler(event));
-  });
+  }) as Awaited<ReturnType<T>>;
 }
 export const lazyEventHandler = defineLazyEventHandler;


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Currently we lose all type inference with lazy event handlers. This fixes it by ensuring types flow upward..

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
