### PR TITLE
fix: split `set-cookie` value when handling web responses

### DIFF
--- a/src/utils/response.ts
+++ b/src/utils/response.ts
@@ -4,6 +4,7 @@ import type { Socket } from "node:net";
 import type { H3Event } from "../event";
 import { MIMES } from "./consts";
 import { sanitizeStatusCode, sanitizeStatusMessage } from "./sanitize";
+import { splitCookiesString } from "./cookie";
 
 const defer =
   typeof setImmediate === "undefined" ? (fn: () => any) => fn() : setImmediate;
@@ -276,9 +277,14 @@ export function writeEarlyHints(
 }
 
 export function sendWebResponse(event: H3Event, response: Response) {
-  for (const [key, value] of response.headers.entries()) {
-    event.node.res.setHeader(key, value);
+  for (const [key, value] of response.headers) {
+    if (key === "set-cookie") {
+      event.node.res.setHeader(key, splitCookiesString(value));
+    } else {
+      event.node.res.setHeader(key, value);
+    }
   }
+
   if (response.status) {
     event.node.res.statusCode = sanitizeStatusCode(
       response.status,


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

Resolves https://github.com/unjs/h3/issues/439

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
