### PR TITLE
fix: append `set-cookie` headers in web reponse

### DIFF
--- a/src/utils/response.ts
+++ b/src/utils/response.ts
@@ -279,7 +279,7 @@ export function writeEarlyHints(
 export function sendWebResponse(event: H3Event, response: Response) {
   for (const [key, value] of response.headers) {
     if (key === "set-cookie") {
-      event.node.res.setHeader(key, splitCookiesString(value));
+      event.node.res.appendHeader(key, splitCookiesString(value));
     } else {
       event.node.res.setHeader(key, value);
     }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

https://github.com/Hebilicious/authjs-nuxt/pull/38

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

It's possible that a Header object has multiple "set-cookie" headers.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
