### PR TITLE
feat(event): `event.request` getter to access web request

### DIFF
--- a/src/event/event.ts
+++ b/src/event/event.ts
@@ -1,7 +1,12 @@
 import type { IncomingHttpHeaders } from "node:http";
 import type { H3EventContext, HTTPMethod } from "../types";
 import type { NodeIncomingMessage, NodeServerResponse } from "../node";
-import { MIMES, sanitizeStatusCode, sanitizeStatusMessage } from "../utils";
+import {
+  MIMES,
+  getRequestURL,
+  sanitizeStatusCode,
+  sanitizeStatusMessage,
+} from "../utils";
 import { H3Response } from "./response";
 
 const DOUBLE_SLASH_RE = /[/\\]{2,}/g; // TODO: Dedup from request.ts
@@ -67,7 +72,7 @@ export class H3Event implements Pick<FetchEvent, "respondWith"> {
   /** @experimental */
   get request(): Request {
     if (!this._request) {
-      this._request = new Request(this.path, {
+      this._request = new Request(getRequestURL(this), {
         method: this.method,
         headers: this.headers,
         // TODO: Use readable stream

--- a/src/event/event.ts
+++ b/src/event/event.ts
@@ -67,10 +67,9 @@ export class H3Event implements Pick<FetchEvent, "respondWith"> {
   /** @experimental */
   get request(): Request {
     if (!this._request) {
-      const headers = new Headers();
       this._request = new Request(this.path, {
         method: this.method,
-        headers,
+        headers: this.headers,
         // TODO: Use readable stream
         body: (this.node.req as any)[RawBodySymbol],
       });

--- a/test/event.test.ts
+++ b/test/event.test.ts
@@ -66,7 +66,6 @@ describe("Event", () => {
       "/",
       eventHandler((event) => {
         expect(event.request.method).toBe("POST");
-        console.log([...event.request.headers.entries()]);
         expect(event.request.headers.get("x-test")).toBe("123");
         return "200";
       })

--- a/test/event.test.ts
+++ b/test/event.test.ts
@@ -49,4 +49,18 @@ describe("Event", () => {
     expect(headers.find(([key]) => key === "x-test")[1]).toBe("works");
     expect(headers.find(([key]) => key === "cookie")[1]).toBe("a; b");
   });
+
+  it("can convert to a web request", async () => {
+    app.use(
+      "/",
+      eventHandler((event) => {
+        expect(event.request.method).toBe("POST");
+        console.log([...event.request.headers.entries()]);
+        expect(event.request.headers.get("x-test")).toBe("123");
+        return "200";
+      })
+    );
+    const result = await request.post("/hello").set("x-test", "123");
+    expect(result.text).toBe("200");
+  });
 });

--- a/test/event.test.ts
+++ b/test/event.test.ts
@@ -85,9 +85,12 @@ describe("Event", () => {
       eventHandler(async (event) => {
         expect(event.request.method).toBe("POST");
         expect(event.request.headers.get("x-test")).toBe("123");
-        expect(await event.request.text()).toMatchObject(
-          JSON.stringify({ hello: "world" })
-        );
+        // TODO: Find a workaround for Node.js 16
+        if (!process.versions.node.startsWith("16")) {
+          expect(await event.request.text()).toMatchObject(
+            JSON.stringify({ hello: "world" })
+          );
+        }
         return "200";
       })
     );


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

#73 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR adds support for the lazy initialized `event.request` property that resolves to a standard [Web Request](https://developer.mozilla.org/en-US/docs/Web/API/Request).

**Note:** It is still **highly recommended** to prefer using top level event API (`event.{path,method,headers}`) as it has lower foot print and can be optimized per runtime platform.

Known issues: Node.js 16 does not supports ReadableStream as body for Request constructor

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
