### PR TITLE
feat(event): support `event.url`

### DIFF
--- a/src/event/event.ts
+++ b/src/event/event.ts
@@ -1,7 +1,12 @@
 import type { IncomingHttpHeaders } from "node:http";
 import type { H3EventContext, HTTPMethod } from "../types";
 import type { NodeIncomingMessage, NodeServerResponse } from "../node";
-import { MIMES, sanitizeStatusCode, sanitizeStatusMessage } from "../utils";
+import {
+  MIMES,
+  getRequestURL,
+  sanitizeStatusCode,
+  sanitizeStatusMessage,
+} from "../utils";
 import { H3Response } from "./response";
 
 const DOUBLE_SLASH_RE = /[/\\]{2,}/g; // TODO: Dedup from request.ts
@@ -22,6 +27,7 @@ export class H3Event implements Pick<FetchEvent, "respondWith"> {
   _method: HTTPMethod | undefined;
   _headers: Headers | undefined;
   _path: string | undefined;
+  _url: URL | undefined;
 
   // Response
   _handled = false;
@@ -43,6 +49,13 @@ export class H3Event implements Pick<FetchEvent, "respondWith"> {
       this._path = this._originalPath.replace(DOUBLE_SLASH_RE, "/");
     }
     return this._path;
+  }
+
+  get url() {
+    if (!this._url) {
+      this._url = getRequestURL(this);
+    }
+    return this._url;
   }
 
   get handled(): boolean {

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -124,6 +124,6 @@ export function getRequestURL(
 ) {
   const host = getRequestHost(event, opts);
   const protocol = getRequestProtocol(event);
-  const path = getRequestPath(event);
+  const path = event.path;
   return new URL(path, `${protocol}://${host}`);
 }

--- a/test/event.test.ts
+++ b/test/event.test.ts
@@ -49,4 +49,15 @@ describe("Event", () => {
     expect(headers.find(([key]) => key === "x-test")[1]).toBe("works");
     expect(headers.find(([key]) => key === "cookie")[1]).toBe("a; b");
   });
+
+  it("can get request url", async () => {
+    app.use(
+      "/",
+      eventHandler((event) => {
+        return event.url;
+      })
+    );
+    const result = await request.get("/hello");
+    expect(result.text).toMatch(/http:\/\/127.0.0.1:\d+\/hello/);
+  });
 });


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

Related / Needed by #454

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This adds `event.url` with a lazy initializer to access the request URL. 

By default, we use `getRequestURL` with default options (trusts `x-forwarded-proto` as a boolean and ignores `x-forwarded-host`)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
