### PR TITLE
test: enable polyfills for node 16

### DIFF
--- a/test/_setup.ts
+++ b/test/_setup.ts
@@ -1,0 +1,1 @@
+import "node-fetch-native/polyfill";

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -34,7 +34,7 @@ describe("app", () => {
     expect(res.body).toEqual({ url: "/" });
   });
 
-  it.runIf(responseSupported)("can return Response directly", async () => {
+  it("can return Response directly", async () => {
     app.use(
       "/",
       eventHandler(
@@ -74,7 +74,7 @@ describe("app", () => {
     }
   });
 
-  it.runIf(blobSupported)("can return Blob directly", async () => {
+  it("can return Blob directly", async () => {
     app.use(
       eventHandler(
         () =>
@@ -139,7 +139,7 @@ describe("app", () => {
     expect(JSON.parse(res.text).statusMessage).toBe("test");
   });
 
-  it.runIf(readableStreamSupported)("Web Stream", async () => {
+  it("Web Stream", async () => {
     app.use(
       eventHandler(() => {
         return new ReadableStream({
@@ -157,7 +157,7 @@ describe("app", () => {
     expect(res.header["transfer-encoding"]).toBe("chunked");
   });
 
-  it.runIf(readableStreamSupported)("Web Stream with Error", async () => {
+  it("Web Stream with Error", async () => {
     app.use(
       eventHandler(() => {
         return new ReadableStream({

--- a/test/event.test.ts
+++ b/test/event.test.ts
@@ -8,8 +8,6 @@ import {
   getMethod,
 } from "../src";
 
-const supportsHeaders = typeof Headers !== "undefined";
-
 describe("Event", () => {
   let app: App;
   let request: SuperTest<Test>;
@@ -32,7 +30,7 @@ describe("Event", () => {
     expect(result.text).toBe("200");
   });
 
-  it.runIf(supportsHeaders)("can read the headers", async () => {
+  it("can read the headers", async () => {
     app.use(
       "/",
       eventHandler((event) => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,8 +2,9 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
+    setupFiles: ["./test/_setup"],
     coverage: {
-      reporter: ["text", "clover", "json"]
-    }
-  }
+      reporter: ["text", "clover", "json"],
+    },
+  },
 });


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Node.js 16 is still in LTS-supported mode till Sep this year and we might need to support it for a little bit longer. While it hurts, we need to make sure it is supported until then (via polyfills at least)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
