### PR TITLE
feat(event): `event.body` with readable stream

### DIFF
--- a/test/event.test.ts
+++ b/test/event.test.ts
@@ -58,4 +58,24 @@ describe("Event", () => {
     const result = await request.get("/hello");
     expect(result.text).toMatch(/http:\/\/127.0.0.1:\d+\/hello/);
   });
+
+  it("can read request body", async () => {
+    app.use(
+      "/",
+      eventHandler(async (event) => {
+        const bodyStream = event.body as unknown as NodeJS.ReadableStream;
+        let bytes = 0;
+        for await (const chunk of bodyStream) {
+          bytes += chunk.length;
+        }
+        return {
+          bytes,
+        };
+      })
+    );
+
+    const result = await request.post("/hello").send(Buffer.from([1, 2, 3]));
+
+    expect(result.body).toMatchObject({ bytes: 3 });
+  });
 });


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

#73, Needed by #454

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR adds an experimental getter to the `event` object in order to access body via a lazy readable stream

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
