### PR TITLE
fix(event): do not remove double slashes from query

### DIFF
--- a/src/event/event.ts
+++ b/src/event/event.ts
@@ -61,11 +61,11 @@ export class H3Event implements Pick<FetchEvent, "respondWith"> {
 
   get path() {
     if (!this._path) {
-      const hasQuery = this._originalPath.includes('?');
+      const hasQuery = this._originalPath.includes("?");
 
       if (hasQuery) {
-        const [basePath, query] = this._originalPath.split('?');
-        this._path = basePath.replace(DOUBLE_SLASH_RE, "/") + '?' + query;
+        const [basePath, query] = this._originalPath.split("?");
+        this._path = basePath.replace(DOUBLE_SLASH_RE, "/") + "?" + query;
       } else {
         this._path = this._originalPath.replace(DOUBLE_SLASH_RE, "/");
       }

--- a/test/event.test.ts
+++ b/test/event.test.ts
@@ -107,14 +107,13 @@ describe("Event", () => {
     app.use(
       "/",
       eventHandler((event) => {
-        expect(event.path).toBe('/?url=https://example.com');
+        expect(event.path).toBe("/?url=https://example.com");
         return "200";
       })
     );
 
-    const result = await request
-      .get('/?url=https://example.com');
+    const result = await request.get("/?url=https://example.com");
 
     expect(result.text).toBe("200");
-  })
+  });
 });


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

https://github.com/unjs/h3/issues/463
(also see added test case)

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves unjs/nitro#1337" -->

Currently the regex replaces all occurrences of multiple `/` with a single `/`. This is desired, but only for the `path`, not `query` part of the URL. This PR ensures the replacement is only done to the part of path coming before `?`. There is no `ufo` helper for extracting just the path nor for detecting if path includes query - therefore I have used good old `.includes('?')` and `.split('?')`.

There is [cleanDoubleSlashes](https://github.com/unjs/ufo/blob/main/src/utils.ts#L92-L97) available in ufo, but it seems to suffer from the same issue. May be worth fixing there and updating h3 to use ufo helper.

Resolves https://github.com/unjs/h3/issues/463

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
