### PR TITLE
fix(proxy): transparently forward errors when passing ofetch

### DIFF
--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -9,7 +9,7 @@ export type Duplex = "half" | "full";
 
 export interface ProxyOptions {
   headers?: RequestHeaders | HeadersInit;
-  fetchOptions?: RequestInit & { duplex?: Duplex };
+  fetchOptions?: RequestInit & { duplex?: Duplex } & { ignoreResponseError?: boolean };
   fetch?: typeof fetch;
   sendStream?: boolean;
   streamRequest?: boolean;
@@ -76,6 +76,7 @@ export async function sendProxy(
 ) {
   const response = await _getFetch(opts.fetch)(target, {
     headers: opts.headers as HeadersInit,
+    ignoreResponseError: true, // make $ofetch.raw transparent
     ...opts.fetchOptions,
   });
   event.node.res.statusCode = sanitizeStatusCode(

--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -9,7 +9,9 @@ export type Duplex = "half" | "full";
 
 export interface ProxyOptions {
   headers?: RequestHeaders | HeadersInit;
-  fetchOptions?: RequestInit & { duplex?: Duplex } & { ignoreResponseError?: boolean };
+  fetchOptions?: RequestInit & { duplex?: Duplex } & {
+    ignoreResponseError?: boolean;
+  };
   fetch?: typeof fetch;
   sendStream?: boolean;
   streamRequest?: boolean;


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

https://github.com/unjs/h3/issues/464

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

As discussed in https://github.com/unjs/h3/issues/464 and https://github.com/unjs/nitro/pull/1489.

`ProxyOptions` type updated to allow overriding the default value (`true`).

---

Is it **breaking change**?

I would say so, users may depend on error masking. This is not strictly a bug. Mandatory xkcd: https://xkcd.com/1172/

---

I personally dislike this solution a lot; if we allow freedom of passing fetch implementation, it should be up to the callee to configure the behavior of their implementation exactly as they like. If it's required to pass option to do so, they already can do so with `fetchOptions`.

Forcing `ignoreResponseError: true` is implicitly re-configuring non-default user-passed implementation. I think better approach is to allow the freedom along with passing the responsibility. Another edge-case is when user passes fetch implementation which also supports `ignoreResponseError` or throws on unknown parameters - both sound plausible to me.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
