### PR TITLE
fix: keep backward compatibility with `event.node.req.url`

### DIFF
--- a/src/event/event.ts
+++ b/src/event/event.ts
@@ -9,9 +9,6 @@ import {
 } from "../utils";
 import { H3Response } from "./response";
 
-// TODO: Dedup from request.ts
-const DOUBLE_SLASH_RE = /[/\\]{2,}/g;
-
 // TODO: Dedup from body.ts
 const PayloadMethods: Set<HTTPMethod> = new Set([
   "PATCH",
@@ -64,17 +61,7 @@ export class H3Event<
   }
 
   get path() {
-    if (!this._path) {
-      const hasQuery = this._originalPath.includes("?");
-
-      if (hasQuery) {
-        const [basePath, query] = this._originalPath.split("?");
-        this._path = basePath.replace(DOUBLE_SLASH_RE, "/") + "?" + query;
-      } else {
-        this._path = this._originalPath.replace(DOUBLE_SLASH_RE, "/");
-      }
-    }
-    return this._path;
+    return this._path || this.node.req.url || "/";
   }
 
   get url() {

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -127,9 +127,16 @@ export function getRequestProtocol(
   return (event.node.req.connection as any).encrypted ? "https" : "http";
 }
 
-/** @deprecated Use `event.path` directly */
+const DOUBLE_SLASH_RE = /[/\\]{2,}/g;
+
 export function getRequestPath(event: H3Event): string {
-  return event.path;
+  const path = event._originalPath.replace(DOUBLE_SLASH_RE, "/");
+  if (path.includes("?")) {
+    const [basePath, query] = path.split("?");
+    return basePath.replace(DOUBLE_SLASH_RE, "/") + "?" + query;
+  } else {
+    return path.replace(DOUBLE_SLASH_RE, "/");
+  }
 }
 
 export function getRequestURL(
@@ -138,6 +145,6 @@ export function getRequestURL(
 ) {
   const host = getRequestHost(event, opts);
   const protocol = getRequestProtocol(event);
-  const path = event.path;
+  const path = getRequestPath(event);
   return new URL(path, `${protocol}://${host}`);
 }

--- a/src/utils/route.ts
+++ b/src/utils/route.ts
@@ -4,16 +4,27 @@ import { eventHandler } from "../event";
 
 export function useBase(base: string, handler: EventHandler): EventHandler {
   base = withoutTrailingSlash(base);
-  if (!base) {
+
+  if (!base || base === "/") {
     return handler;
   }
+
   return eventHandler(async (event) => {
-    const _path = event._path;
+    // Keep original incoming url accessable
+    (event.node.req as { originalUrl?: string }).originalUrl =
+      (event.node.req as { originalUrl?: string }).originalUrl ||
+      event.node.req.url ||
+      "/";
+
+    const _path = event._path || event.node.req.url || "/";
+
     event._path = withoutBase(event.path || "/", base);
+    event.node.req.url = event._path;
+
     try {
       return await handler(event);
     } finally {
-      event._path = _path;
+      event._path = event.node.req.url = _path;
     }
   });
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

(failing tests against nuxt)

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR adds backward compatibility to the changes in https://github.com/unjs/h3/pull/438 for `event.path` support. While we ideally could benefit from a single and normalized getter, it makes issues on edge cases when we are depending on legacy express like behavior (nuxt vite intention) to allow:

- Supporting not normalized routes with double slashes (`/module/@fs//...`)
- Supporting to manually modify event path by modifying `event.node.req.url` directly
- Allowing to use custom modified URL in same tick

Because of this, this PR reverts `event.path` behavior to _prefer_ future `_path` prop if exists and otherwise return (not normalized) `node.req.url` and also preserves `node.req.originalPath`

Also to avoid issues with same tick modification, app handler directly reads from `event.node.req.url` without depending on getter which strangely keeps failing when using getter.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
