### PR TITLE
fix(proxy): merge overriden headers with different case

### DIFF
--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -232,7 +232,9 @@ function mergeHeaders(
   const merged = new Headers(defaults);
   for (const input of _inputs) {
     for (const [key, value] of Object.entries(input!)) {
-      merged.set(key, value);
+      if (value !== undefined) {
+        merged.set(key, value);
+      }
     }
   }
   return merged;

--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -232,9 +232,7 @@ function mergeHeaders(
   const merged = new Headers(defaults);
   for (const input of _inputs) {
     for (const [key, value] of Object.entries(input!)) {
-      if (value !== undefined) {
-        merged.set(key, value);
-      }
+      merged.set(key, value);
     }
   }
   return merged;

--- a/test/proxy.test.ts
+++ b/test/proxy.test.ts
@@ -87,7 +87,13 @@ describe("", () => {
       app.use(
         "/",
         eventHandler((event) => {
-          return proxyRequest(event, url + "/debug", { fetch });
+          return proxyRequest(event, url + "/debug", {
+            fetch,
+            headers: { "x-custom1": "overriden" },
+            fetchOptions: {
+              headers: { "x-custom2": "overriden" },
+            },
+          });
         })
       );
 
@@ -96,13 +102,19 @@ describe("", () => {
         body: "hello",
         headers: {
           "content-type": "text/custom",
-          "x-custom": "hello",
+          "X-Custom1": "user",
+          "X-Custom2": "user",
+          "X-Custom3": "user",
         },
       }).then((r) => r.json());
 
       const { headers, ...data } = result;
       expect(headers["content-type"]).toEqual("text/custom");
-      expect(headers["x-custom"]).toEqual("hello");
+
+      expect(headers["x-custom1"]).toEqual("overriden");
+      expect(headers["x-custom2"]).toEqual("overriden");
+      expect(headers["x-custom3"]).toEqual("user");
+
       expect(data).toMatchInlineSnapshot(`
         {
           "body": "hello",


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

Resolves #450

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When custom proxy headers are configured, they should override regardless of casing differences. This PR does this by introducing an internal util leveraging `Headers` object.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
