### PR TITLE
fix(app): use default error handler if `onError` does not handles reponse

### DIFF
--- a/src/node.ts
+++ b/src/node.ts
@@ -64,12 +64,14 @@ export function toNodeListener(app: App): NodeListener {
 
       if (app.options.onError) {
         await app.options.onError(error, event);
-      } else {
-        if (error.unhandled || error.fatal) {
-          console.error("[h3]", error.fatal ? "[fatal]" : "[unhandled]", error); // eslint-disable-line no-console
-        }
-        await sendError(event, error, !!app.options.debug);
       }
+      if (event.handled) {
+        return;
+      }
+      if (error.unhandled || error.fatal) {
+        console.error("[h3]", error.fatal ? "[fatal]" : "[unhandled]", error); // eslint-disable-line no-console
+      }
+      await sendError(event, error, !!app.options.debug);
     }
   };
   return toNodeHandle;


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When a custom `onError` is in place and it does not handle response, it can cause pending responses. This PR changes implementation to wait on `onError` and try to handle response by h3 directly if it is not handled yet.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
