### PR TITLE
feat: preserve and make error cause accessable

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -6,7 +6,7 @@ import {
   eventHandler,
   H3Event,
 } from "./event";
-import { createError } from "./error";
+import { H3Error, createError } from "./error";
 import {
   send,
   sendStream,
@@ -48,7 +48,7 @@ export interface AppUse {
 
 export interface AppOptions {
   debug?: boolean;
-  onError?: (error: Error, event: H3Event) => any;
+  onError?: (error: H3Error, event: H3Event) => any;
 }
 
 export interface App {

--- a/src/error.ts
+++ b/src/error.ts
@@ -25,6 +25,17 @@ export class H3Error extends Error {
   unhandled = false;
   statusMessage?: string;
   data?: any;
+  cause?: Error | unknown;
+
+  constructor(message: string, opts: { cause?: unknown } = {}) {
+    // @ts-ignore https://v8.dev/features/error-cause
+    super(message, opts);
+
+    // Polyfill cause for other runtimes
+    if (opts.cause && !this.cause) {
+      this.cause = opts.cause;
+    }
+  }
 
   toJSON() {
     const obj: Pick<
@@ -63,11 +74,9 @@ export function createError(
     return input;
   }
 
-  const err = new H3Error(
-    input.message ?? input.statusMessage ?? "",
-    // @ts-ignore https://v8.dev/features/error-cause
-    input.cause ? { cause: input.cause } : undefined
-  );
+  const err = new H3Error(input.message ?? input.statusMessage ?? "", {
+    cause: input.cause || input,
+  });
 
   if ("stack" in input) {
     try {

--- a/src/error.ts
+++ b/src/error.ts
@@ -25,7 +25,7 @@ export class H3Error extends Error {
   unhandled = false;
   statusMessage?: string;
   data?: any;
-  cause?: Error | unknown;
+  cause?: unknown;
 
   constructor(message: string, opts: { cause?: unknown } = {}) {
     // @ts-ignore https://v8.dev/features/error-cause


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

Resolves #377

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR improves H3Error class with a polyfill to support [v8 error cause](https://v8.dev/features/error-cause) universally. 

The `createError` wrapper also always provides input (or `input.cause` if provided) as cause so we can always access original error/object.

Another small fix: `onError` types fixed. It accepts an H3Error.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
