### PR TITLE
refactor(event): use `sendWebResponse` for `event.respondWith`

### DIFF
--- a/src/event/index.ts
+++ b/src/event/index.ts
@@ -1,4 +1,6 @@
 export * from "./event";
-export * from "./headers";
-export * from "./response";
 export * from "./utils";
+
+// TODO: Drop in next major version
+export * from "./polyfills/headers";
+export * from "./polyfills/response";

--- a/src/event/polyfills/headers.ts
+++ b/src/event/polyfills/headers.ts
@@ -1,3 +1,7 @@
+/**
+ * @deprecated Please use native web Headers
+ * https://developer.mozilla.org/en-US/docs/Web/API/Headers
+ */
 export class H3Headers implements Headers {
   _headers: Record<string, string>;
 

--- a/src/event/polyfills/response.ts
+++ b/src/event/polyfills/response.ts
@@ -1,6 +1,10 @@
-import type { EventHandlerResponse } from "../types";
+import type { EventHandlerResponse } from "../../types";
 import { H3Headers } from "./headers";
 
+/**
+ * @deprecated Please use native web Response
+ * https://developer.mozilla.org/en-US/docs/Web/API/Response
+ */
 export class H3Response implements Response {
   readonly headers: H3Headers;
   readonly status: number;

--- a/src/utils/response.ts
+++ b/src/utils/response.ts
@@ -300,7 +300,10 @@ export function writeEarlyHints(
   }
 }
 
-export function sendWebResponse(event: H3Event, response: Response) {
+export function sendWebResponse(
+  event: H3Event,
+  response: Response
+): void | Promise<void> {
   for (const [key, value] of response.headers) {
     if (key === "set-cookie") {
       event.node.res.appendHeader(key, splitCookiesString(value));
@@ -322,7 +325,8 @@ export function sendWebResponse(event: H3Event, response: Response) {
     event.node.res.setHeader("location", response.url);
   }
   if (!response.body) {
-    return event.node.res.end();
+    event.node.res.end();
+    return;
   }
   return sendStream(event, response.body);
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR deprecates legacy H3Request/H3Headers and uses new `sendWebResponse` utility for `event.respondWith` in order to reduce bundle size and uses latest/consistent response handling.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
