### PR TITLE
feat(app): `onRequest`, `onBeforeResponse` and `onAfterResponse` global hooks

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -156,6 +156,9 @@ export function createAppEventHandler(stack: Stack, options: AppOptions) {
 
       // Already handled
       if (event.handled) {
+        if (options.onResponse) {
+          await options.onResponse(event, val);
+        }
         return;
       }
     }
@@ -165,6 +168,10 @@ export function createAppEventHandler(stack: Stack, options: AppOptions) {
         statusCode: 404,
         statusMessage: `Cannot find any path matching ${event.path || "/"}.`,
       });
+    }
+
+    if (options.onResponse) {
+      await options.onResponse(event, undefined);
     }
   });
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -48,7 +48,6 @@ export interface AppUse {
 
 export interface AppOptions {
   debug?: boolean;
-  jsonSpace?: number;
   onError?: (error: H3Error, event: H3Event) => any;
   onRequest?: (event: H3Event) => void | Promise<void>;
   onBeforeResponse?: (

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -15,11 +15,18 @@ describe("app", () => {
   let request: SuperTest<Test>;
 
   const onRequest = vi.fn();
-  const onResponse = vi.fn();
+  const onBeforeResponse = vi.fn();
+  const onAfterResponse = vi.fn();
   const onError = vi.fn();
 
   beforeEach(() => {
-    app = createApp({ debug: true, onError, onRequest, onResponse });
+    app = createApp({
+      debug: true,
+      onError,
+      onRequest,
+      onBeforeResponse,
+      onAfterResponse,
+    });
     request = supertest(toNodeListener(app));
   });
 
@@ -382,13 +389,16 @@ describe("app", () => {
   });
 
   it("calls onRequest and onResponse", async () => {
-    app.use(() => "Hello World!");
+    app.use(() => Promise.resolve("Hello World!"));
     await request.get("/foo");
 
     expect(onRequest).toHaveBeenCalledTimes(1);
     expect(onRequest.mock.calls[0][0].path).toBe("/foo");
 
-    expect(onResponse).toHaveBeenCalledTimes(1);
-    expect(onResponse.mock.calls[0][1]).toBe("Hello World!");
+    expect(onBeforeResponse).toHaveBeenCalledTimes(1);
+    expect(onBeforeResponse.mock.calls[0][1].body).toBe("Hello World!");
+
+    expect(onAfterResponse).toHaveBeenCalledTimes(1);
+    expect(onAfterResponse.mock.calls[0][1].body).toBe("Hello World!");
   });
 });


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

Resolves #447

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR adds 3 new global hooks (options) `onRequest(event)`, `onBeforeResponse(event, { body })`, `onAfterResponse(event, { body }?)` useful for debugging and request/response interception.

Notes:
- All hooks support async but it is highly discouraged to avoid Promises and block all requests
- The `onResponse` hooks, only receive response with body when a handled directly returns it (not when using send* methods).
- Only one hook is supported in h3 level. Frameworks can leverage unjs/hookable to support more advanced integrations.


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
