### PR TITLE
feat: object-syntax event handlers

### DIFF
--- a/src/event/utils.ts
+++ b/src/event/utils.ts
@@ -21,7 +21,7 @@ export function defineEventHandler<
   Request = EventHandlerRequest,
   Response = EventHandlerResponse,
 >(
-  def: EventHandler<
+  handler: EventHandler<
     Request extends EventHandlerRequest ? Request : any,
     Request extends EventHandlerRequest ? Response : Request
   >,
@@ -33,17 +33,19 @@ export function defineEventHandler<
   Request extends EventHandlerRequest = EventHandlerRequest,
   Response = EventHandlerResponse,
 >(
-  def: EventHandler<Request, Response> | EventHandlerObject<Request, Response>,
+  handler:
+    | EventHandler<Request, Response>
+    | EventHandlerObject<Request, Response>,
 ): EventHandler<Request, Response> {
   // Function Fyntax
-  if (typeof def === "function") {
-    return Object.assign(def, { __is_handler__: true });
+  if (typeof handler === "function") {
+    return Object.assign(handler, { __is_handler__: true });
   }
   // Object Syntax
-  const handler: EventHandler<Request, any> = (event) => {
-    return _callHandler(event, def);
+  const _handler: EventHandler<Request, any> = (event) => {
+    return _callHandler(event, handler);
   };
-  return Object.assign(handler, { __is_handler__: true });
+  return Object.assign(_handler, { __is_handler__: true });
 }
 
 async function _callHandler(event: H3Event, handler: EventHandlerObject) {

--- a/src/event/utils.ts
+++ b/src/event/utils.ts
@@ -3,7 +3,6 @@ import type {
   LazyEventHandler,
   EventHandlerRequest,
   EventHandlerResponse,
-  EventHandlerInput,
   EventHandlerObject,
 } from "../types";
 import type { H3Event } from "./event";
@@ -12,7 +11,9 @@ export function defineEventHandler<
   Request extends EventHandlerRequest = EventHandlerRequest,
   Response = EventHandlerResponse,
 >(
-  handler: EventHandlerInput<Request, Response>,
+  handler:
+    | EventHandler<Request, Response>
+    | EventHandlerObject<Request, Response>,
 ): EventHandler<Request, Response>;
 // TODO: remove when appropriate
 // This signature provides backwards compatibility with previous signature where first generic was return type
@@ -20,7 +21,7 @@ export function defineEventHandler<
   Request = EventHandlerRequest,
   Response = EventHandlerResponse,
 >(
-  handler: EventHandler<
+  def: EventHandler<
     Request extends EventHandlerRequest ? Request : any,
     Request extends EventHandlerRequest ? Response : Request
   >,
@@ -32,17 +33,17 @@ export function defineEventHandler<
   Request extends EventHandlerRequest = EventHandlerRequest,
   Response = EventHandlerResponse,
 >(
-  handler: EventHandlerInput<Request, Response>,
+  def: EventHandler<Request, Response> | EventHandlerObject<Request, Response>,
 ): EventHandler<Request, Response> {
   // Function Fyntax
-  if (typeof handler === "function") {
-    return Object.assign(handler, { __is_handler__: true });
+  if (typeof def === "function") {
+    return Object.assign(def, { __is_handler__: true });
   }
   // Object Syntax
-  const wrapper: EventHandler<Request, any> = (event) => {
-    return _callHandler(event, handler);
+  const handler: EventHandler<Request, any> = (event) => {
+    return _callHandler(event, def);
   };
-  return Object.assign(wrapper, { __is_handler__: true });
+  return Object.assign(handler, { __is_handler__: true });
 }
 
 async function _callHandler(event: H3Event, handler: EventHandlerObject) {

--- a/src/event/utils.ts
+++ b/src/event/utils.ts
@@ -5,7 +5,7 @@ import type {
   EventHandlerResponse,
   EventHandlerInput,
 } from "../types";
-import { readBody } from "src/utils";
+import { readBody } from "../utils";
 
 export function defineEventHandler<
   Request extends EventHandlerRequest = EventHandlerRequest,

--- a/src/event/utils.ts
+++ b/src/event/utils.ts
@@ -1,4 +1,4 @@
-import { validateData } from "../utils/internal/validate"
+import { validateData } from "../utils/internal/validate";
 import type {
   EventHandler,
   LazyEventHandler,
@@ -11,9 +11,15 @@ import type {
 export function defineEventHandler<
   Request extends EventHandlerRequest = EventHandlerRequest,
   Response = any,
-  Validator extends ValidateFunction<EventHandlerRequest> = ValidateFunction<EventHandlerRequest>,
-  ValidatedRequest extends EventHandlerRequest = Validator extends ValidateFunction<infer T> ? T : EventHandlerRequest,
->(handler: EventHandlerInput<Request, Response, Validator, ValidatedRequest>): EventHandler<Request, Response>;
+  Validator extends
+    ValidateFunction<EventHandlerRequest> = ValidateFunction<EventHandlerRequest>,
+  ValidatedRequest extends
+    EventHandlerRequest = Validator extends ValidateFunction<infer T>
+    ? T
+    : EventHandlerRequest,
+>(
+  handler: EventHandlerInput<Request, Response, Validator, ValidatedRequest>,
+): EventHandler<Request, Response>;
 // TODO: remove when appropriate
 // This signature provides backwards compatibility with previous signature where first generic was return type
 export function defineEventHandler<
@@ -30,14 +36,22 @@ export function defineEventHandler<
 >;
 export function defineEventHandler<
   Request extends EventHandlerRequest = EventHandlerRequest,
-  Response = EventHandlerResponse,
->(handler: EventHandlerInput<Request, Response>): EventHandler<Request, Response> {
-  if (typeof handler === 'function') {
+  Response = any,
+  Validator extends
+    ValidateFunction<EventHandlerRequest> = ValidateFunction<EventHandlerRequest>,
+  ValidatedRequest extends
+    EventHandlerRequest = Validator extends ValidateFunction<infer T>
+    ? T
+    : EventHandlerRequest,
+>(
+  handler: EventHandlerInput<Request, Response, Validator, ValidatedRequest>,
+): EventHandler<Request, Response> {
+  if (typeof handler === "function") {
     return Object.assign(handler, { __is_handler__: true });
   }
   const wrapper: EventHandler<Request, any> = async (event) => {
     if (handler.validate) {
-      await validateData(event, handler.validate)
+      await validateData(event, handler.validate);
     }
     for (const hook of handler.before || []) {
       await hook(event);

--- a/src/event/utils.ts
+++ b/src/event/utils.ts
@@ -37,7 +37,7 @@ export function defineEventHandler<
     | EventHandler<Request, Response>
     | EventHandlerObject<Request, Response>,
 ): EventHandler<Request, Response> {
-  // Function Fyntax
+  // Function Syntax
   if (typeof handler === "function") {
     return Object.assign(handler, { __is_handler__: true });
   }

--- a/src/event/utils.ts
+++ b/src/event/utils.ts
@@ -6,7 +6,7 @@ import type {
   EventHandlerInput,
   EventHandlerObject,
 } from "../types";
-import { H3Event } from "./event";
+import type { H3Event } from "./event";
 
 export function defineEventHandler<
   Request extends EventHandlerRequest = EventHandlerRequest,

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,6 +48,10 @@ export interface EventHandlerRequest {
   query?: QueryObject;
 }
 
+export interface EventHandlerHook<Request extends EventHandlerRequest = EventHandlerRequest> {
+  (event: H3Event<Request>): void | Promise<void>;
+}
+
 export type InferEventInput<
   Key extends keyof EventHandlerRequest,
   Event extends H3Event,
@@ -61,6 +65,15 @@ export interface EventHandler<
   __is_handler__?: true;
   (event: H3Event<Request>): Response;
 }
+
+export type EventHandlerInput<
+  Request extends EventHandlerRequest = EventHandlerRequest,
+  Response extends EventHandlerResponse = EventHandlerResponse,
+> = {
+  handler(event: H3Event<Request>): Response;
+  before?: EventHandlerHook<Request>[];
+  after?: EventHandlerHook<Request>[];
+} | EventHandler<Request, Response>;
 
 export type LazyEventHandler = () => EventHandler | Promise<EventHandler>;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
 import type { QueryObject } from "ufo";
 import type { H3Event } from "./event";
 import type { Session } from "./utils/session";
-import { ValidateFunction } from "./utils/internal/validate"
+import { ValidateFunction } from "./utils/internal/validate";
 
 export type {
   ValidateFunction,
@@ -49,7 +49,9 @@ export interface EventHandlerRequest {
   query?: QueryObject;
 }
 
-export interface EventHandlerHook<Request extends EventHandlerRequest = EventHandlerRequest> {
+export interface EventHandlerHook<
+  Request extends EventHandlerRequest = EventHandlerRequest,
+> {
   (event: H3Event<Request>): void | Promise<void>;
 }
 
@@ -70,14 +72,20 @@ export interface EventHandler<
 export type EventHandlerInput<
   Request extends EventHandlerRequest = EventHandlerRequest,
   Response extends EventHandlerResponse = EventHandlerResponse,
-  Validator extends ValidateFunction<EventHandlerRequest> = ValidateFunction<EventHandlerRequest>,
-  ValidatedRequest extends EventHandlerRequest = Validator extends ValidateFunction<infer T> ? T : EventHandlerRequest,
-> = {
-  validate?: Validator;
-  handler(event: H3Event<ValidatedRequest>): Response;
-  before?: EventHandlerHook<Request>[];
-  after?: EventHandlerHook<Request>[];
-} | EventHandler<Request, Response>;
+  Validator extends
+    ValidateFunction<EventHandlerRequest> = ValidateFunction<EventHandlerRequest>,
+  ValidatedRequest extends
+    EventHandlerRequest = Validator extends ValidateFunction<infer T>
+    ? T
+    : EventHandlerRequest,
+> =
+  | {
+      validate?: Validator;
+      handler(event: H3Event<ValidatedRequest>): Response;
+      before?: EventHandlerHook<Request>[];
+      after?: EventHandlerHook<Request>[];
+    }
+  | EventHandler<Request, Response>;
 
 export type LazyEventHandler = () => EventHandler | Promise<EventHandler>;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 import type { QueryObject } from "ufo";
 import type { H3Event } from "./event";
 import type { Session } from "./utils/session";
+import { ValidateFunction } from "./utils/internal/validate"
 
 export type {
   ValidateFunction,
@@ -69,8 +70,11 @@ export interface EventHandler<
 export type EventHandlerInput<
   Request extends EventHandlerRequest = EventHandlerRequest,
   Response extends EventHandlerResponse = EventHandlerResponse,
+  Validator extends ValidateFunction<EventHandlerRequest> = ValidateFunction<EventHandlerRequest>,
+  ValidatedRequest extends EventHandlerRequest = Validator extends ValidateFunction<infer T> ? T : EventHandlerRequest,
 > = {
-  handler(event: H3Event<Request>): Response;
+  validate?: Validator;
+  handler(event: H3Event<ValidatedRequest>): Response;
   before?: EventHandlerHook<Request>[];
   after?: EventHandlerHook<Request>[];
 } | EventHandler<Request, Response>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,15 +48,6 @@ export interface EventHandlerRequest {
   query?: QueryObject;
 }
 
-export interface EventHandlerHook<
-  Request extends EventHandlerRequest = EventHandlerRequest,
-> {
-  (
-    event: H3Event<Request>,
-    response?: { body?: EventHandlerRequest["body"] },
-  ): void | Promise<void>;
-}
-
 export type InferEventInput<
   Key extends keyof EventHandlerRequest,
   Event extends H3Event,
@@ -76,14 +67,12 @@ export type EventHandlerObject<
   Response extends EventHandlerResponse = EventHandlerResponse,
 > = {
   handler(event: H3Event<EventHandlerResponse>): Response;
-  before?: EventHandlerHook<Request>[];
-  after?: EventHandlerHook<Request>[];
+  before?: ((event: H3Event<Request>) => void | Promise<void>)[];
+  after?: ((
+    event: H3Event<Request>,
+    response: { body?: Response },
+  ) => void | Promise<void>)[];
 };
-
-export type EventHandlerInput<
-  Request extends EventHandlerRequest = EventHandlerRequest,
-  Response extends EventHandlerResponse = EventHandlerResponse,
-> = EventHandler<Request, Response> | EventHandlerObject<Request, Response>;
 
 export type LazyEventHandler = () => EventHandler | Promise<EventHandler>;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,6 @@
 import type { QueryObject } from "ufo";
 import type { H3Event } from "./event";
 import type { Session } from "./utils/session";
-import { ValidateFunction } from "./utils/internal/validate";
 
 export type {
   ValidateFunction,
@@ -52,7 +51,10 @@ export interface EventHandlerRequest {
 export interface EventHandlerHook<
   Request extends EventHandlerRequest = EventHandlerRequest,
 > {
-  (event: H3Event<Request>): void | Promise<void>;
+  (
+    event: H3Event<Request>,
+    response?: { body?: EventHandlerRequest["body"] },
+  ): void | Promise<void>;
 }
 
 export type InferEventInput<
@@ -72,16 +74,9 @@ export interface EventHandler<
 export type EventHandlerInput<
   Request extends EventHandlerRequest = EventHandlerRequest,
   Response extends EventHandlerResponse = EventHandlerResponse,
-  Validator extends
-    ValidateFunction<EventHandlerRequest> = ValidateFunction<EventHandlerRequest>,
-  ValidatedRequest extends
-    EventHandlerRequest = Validator extends ValidateFunction<infer T>
-    ? T
-    : EventHandlerRequest,
 > =
   | {
-      validate?: Validator;
-      handler(event: H3Event<ValidatedRequest>): Response;
+      handler(event: H3Event<EventHandlerResponse>): Response;
       before?: EventHandlerHook<Request>[];
       after?: EventHandlerHook<Request>[];
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -71,16 +71,19 @@ export interface EventHandler<
   (event: H3Event<Request>): Response;
 }
 
+export type EventHandlerObject<
+  Request extends EventHandlerRequest = EventHandlerRequest,
+  Response extends EventHandlerResponse = EventHandlerResponse,
+> = {
+  handler(event: H3Event<EventHandlerResponse>): Response;
+  before?: EventHandlerHook<Request>[];
+  after?: EventHandlerHook<Request>[];
+};
+
 export type EventHandlerInput<
   Request extends EventHandlerRequest = EventHandlerRequest,
   Response extends EventHandlerResponse = EventHandlerResponse,
-> =
-  | {
-      handler(event: H3Event<EventHandlerResponse>): Response;
-      before?: EventHandlerHook<Request>[];
-      after?: EventHandlerHook<Request>[];
-    }
-  | EventHandler<Request, Response>;
+> = EventHandler<Request, Response> | EventHandlerObject<Request, Response>;
 
 export type LazyEventHandler = () => EventHandler | Promise<EventHandler>;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -66,7 +66,7 @@ export type EventHandlerObject<
   Request extends EventHandlerRequest = EventHandlerRequest,
   Response extends EventHandlerResponse = EventHandlerResponse,
 > = {
-  handler(event: H3Event<EventHandlerResponse>): Response;
+  handler: EventHandler<Request, Response>;
   before?: ((event: H3Event<Request>) => void | Promise<void>)[];
   after?: ((
     event: H3Event<Request>,

--- a/test/types.test-d.ts
+++ b/test/types.test-d.ts
@@ -1,4 +1,4 @@
-import { describe, it, expectTypeOf } from "vitest";
+import { describe, it, expectTypeOf, expect } from "vitest";
 import type { QueryObject } from "ufo";
 import {
   eventHandler,
@@ -11,6 +11,27 @@ import {
 
 describe("types", () => {
   describe("eventHandler", () => {
+    it("object syntax definitions", async () => {
+      const handler = eventHandler({
+        before: [
+          event => {
+            expectTypeOf(event).toEqualTypeOf<H3Event>();
+          }
+        ],
+        async handler(event) {
+          expectTypeOf(event).toEqualTypeOf<H3Event>();
+
+          const body = await readBody(event);
+          // TODO: Default to unknown in next major version
+          expectTypeOf(body).toBeAny();
+          
+          return {
+            foo: "bar",
+          };
+        }
+      })
+      expectTypeOf(await handler({} as H3Event)).toEqualTypeOf<{ foo: string }>();
+    })
     it("return type (inferred)", () => {
       const handler = eventHandler(() => {
         return {

--- a/test/types.test-d.ts
+++ b/test/types.test-d.ts
@@ -1,4 +1,4 @@
-import { describe, it, expectTypeOf, expect } from "vitest";
+import { describe, it, expectTypeOf } from "vitest";
 import type { QueryObject } from "ufo";
 import {
   eventHandler,
@@ -7,6 +7,7 @@ import {
   readBody,
   readValidatedBody,
   getValidatedQuery,
+  ValidateFunction,
 } from "../src";
 
 describe("types", () => {
@@ -31,6 +32,19 @@ describe("types", () => {
         }
       })
       expectTypeOf(await handler({} as H3Event)).toEqualTypeOf<{ foo: string }>();
+    })
+    it("object syntax request validation", () => {
+      eventHandler({
+        validate: <ValidateFunction<{ body: { id: string } }>> function test(event) {
+          expectTypeOf(event).toBeUnknown();
+          return true
+        },
+        async handler(event) {
+          const body = await readBody(event);
+          expectTypeOf(body).toEqualTypeOf<{ id: string }>();
+          return { foo: "bar", };
+        }
+      })
     })
     it("return type (inferred)", () => {
       const handler = eventHandler(() => {

--- a/test/types.test-d.ts
+++ b/test/types.test-d.ts
@@ -7,7 +7,6 @@ import {
   readBody,
   readValidatedBody,
   getValidatedQuery,
-  ValidateFunction,
 } from "../src";
 
 describe("types", () => {
@@ -34,22 +33,6 @@ describe("types", () => {
       expectTypeOf(await handler({} as H3Event)).toEqualTypeOf<{
         foo: string;
       }>();
-    });
-    it("object syntax request validation", () => {
-      eventHandler({
-        validate: <ValidateFunction<{ body: { id: string } }>>(
-          function validate(event) {
-            // TODO: types for event should be provided by custom event validator function
-            expectTypeOf(event).toBeUnknown();
-            return true;
-          }
-        ),
-        async handler(event) {
-          const body = await readBody(event);
-          expectTypeOf(body).toEqualTypeOf<{ id: string }>();
-          return { foo: "bar" };
-        },
-      });
     });
     it("return type (inferred)", () => {
       const handler = eventHandler(() => {

--- a/test/types.test-d.ts
+++ b/test/types.test-d.ts
@@ -15,9 +15,9 @@ describe("types", () => {
     it("object syntax definitions", async () => {
       const handler = eventHandler({
         before: [
-          event => {
+          (event) => {
             expectTypeOf(event).toEqualTypeOf<H3Event>();
-          }
+          },
         ],
         async handler(event) {
           expectTypeOf(event).toEqualTypeOf<H3Event>();
@@ -25,27 +25,32 @@ describe("types", () => {
           const body = await readBody(event);
           // TODO: Default to unknown in next major version
           expectTypeOf(body).toBeAny();
-          
+
           return {
             foo: "bar",
           };
-        }
-      })
-      expectTypeOf(await handler({} as H3Event)).toEqualTypeOf<{ foo: string }>();
-    })
+        },
+      });
+      expectTypeOf(await handler({} as H3Event)).toEqualTypeOf<{
+        foo: string;
+      }>();
+    });
     it("object syntax request validation", () => {
       eventHandler({
-        validate: <ValidateFunction<{ body: { id: string } }>> function test(event) {
-          expectTypeOf(event).toBeUnknown();
-          return true
-        },
+        validate: <ValidateFunction<{ body: { id: string } }>>(
+          function validate(event) {
+            // TODO: types for event should be provided by custom event validator function
+            expectTypeOf(event).toBeUnknown();
+            return true;
+          }
+        ),
         async handler(event) {
           const body = await readBody(event);
           expectTypeOf(body).toEqualTypeOf<{ id: string }>();
-          return { foo: "bar", };
-        }
-      })
-    })
+          return { foo: "bar" };
+        },
+      });
+    });
     it("return type (inferred)", () => {
       const handler = eventHandler(() => {
         return {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

https://github.com/unjs/h3/pull/417
resolves https://github.com/unjs/h3/issues/424

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This supports object-syntax event handlers with the following syntax:

```ts
defineEventHandler({
  handler: () => {},
  before: [],
  after: []
})
```

Helper validate functions need to be drafted that type-hint `event` and infer a return type. (I would suggest we also suggest `validate: { body: () => {}, query: () => {} }` which I think will be easier to directly get a type from as user can just return the validated body/query, which we can then flow through into rest of handlers.)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
