### PR TITLE
feat(event): add default stringify with method and url for better dx

### DIFF
--- a/src/event/event.ts
+++ b/src/event/event.ts
@@ -130,9 +130,18 @@ export class H3Event<
   }
 
   respondWith(response: Response | PromiseLike<Response>): Promise<void> {
+    console.log("aa");
     return Promise.resolve(response).then((_response) =>
       sendWebResponse(this, _response),
     );
+  }
+
+  toString() {
+    return `[${this.method}] ${this.url}`;
+  }
+
+  toJSON() {
+    return this.toString();
   }
 }
 

--- a/src/event/event.ts
+++ b/src/event/event.ts
@@ -130,7 +130,6 @@ export class H3Event<
   }
 
   respondWith(response: Response | PromiseLike<Response>): Promise<void> {
-    console.log("aa");
     return Promise.resolve(response).then((_response) =>
       sendWebResponse(this, _response),
     );


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Using `console.log(event)` or directly returning it, leads to a complex and unreadable output like this:

<img width="448" alt="image" src="https://github.com/unjs/h3/assets/5158436/9eff4dc2-84ed-4c69-a7af-d9d9cc2cf132">


This PR makes it stringified with method and FULL URL:

```
[PATCH] http://127.0.0.1:80/test
```

Note: `toJSON` is also usually expected to return a string and used by JSON.stringify (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toJSON)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
