### PR TITLE
fix(web): use `null` for null body responses

### DIFF
--- a/src/adapters/web.ts
+++ b/src/adapters/web.ts
@@ -37,9 +37,10 @@ async function _handleWebRequest(
     body: request.body,
   });
 
-  const body = nullBodyResponses.has(res.status)
-    ? null
-    : (res.body as BodyInit);
+  const body =
+    nullBodyResponses.has(res.status) || request.method === "HEAD"
+      ? null
+      : (res.body as BodyInit);
 
   return new Response(body, {
     status: res.status,

--- a/src/adapters/web.ts
+++ b/src/adapters/web.ts
@@ -17,6 +17,8 @@ export function toWebHandler(app: App) {
 
 // --- Internal ---
 
+const nullBodyResponses = new Set([101, 204, 205, 304]);
+
 async function _handleWebRequest(
   app: App,
   request: Request,
@@ -35,7 +37,11 @@ async function _handleWebRequest(
     body: request.body,
   });
 
-  return new Response(res.body as BodyInit, {
+  const body = nullBodyResponses.has(res.status)
+    ? null
+    : (res.body as BodyInit);
+
+  return new Response(body, {
     status: res.status,
     statusText: res.statusText,
     headers: res.headers,

--- a/src/adapters/web.ts
+++ b/src/adapters/web.ts
@@ -37,6 +37,7 @@ async function _handleWebRequest(
     body: request.body,
   });
 
+  // https://developer.mozilla.org/en-US/docs/Web/API/Response/body
   const body =
     nullBodyResponses.has(res.status) || request.method === "HEAD"
       ? null


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Reported by @Atinux > @danielroe 

This fixes the issue with null body responses in h3. Once nitro migrates to the web handler, it should fix all possible targets.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
