### PR TITLE
feat: util `getRequestIP` 

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ H3 has a concept of composable utilities that accept `event` (from `eventHandler
 - `getRequestHost(event)`
 - `getRequestProtocol(event)`
 - `getRequestPath(event)`
+- `getRequestIP(event, { xForwardedFor: boolean })`
 
 #### Response
 

--- a/src/adapters/node.ts
+++ b/src/adapters/node.ts
@@ -54,6 +54,7 @@ export function fromNodeMiddleware(
 export function toNodeListener(app: App): NodeListener {
   const toNodeHandle: NodeListener = async function (req, res) {
     const event = createEvent(req, res);
+    event.context.clientAddress = req.socket.remoteAddress
     try {
       await app.handler(event);
     } catch (_error: any) {

--- a/src/adapters/node.ts
+++ b/src/adapters/node.ts
@@ -54,7 +54,6 @@ export function fromNodeMiddleware(
 export function toNodeListener(app: App): NodeListener {
   const toNodeHandle: NodeListener = async function (req, res) {
     const event = createEvent(req, res);
-    event.context.clientAddress = req.socket.remoteAddress;
     try {
       await app.handler(event);
     } catch (_error: any) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,6 +44,8 @@ export interface H3EventContext extends Record<string, any> {
   matchedRoute?: RouteNode;
   /* Cached session data */
   sessions?: Record<string, Session>;
+  /* Trusted IP Address of client */
+  clientAddress?: string
 }
 
 export type EventHandlerResponse<T = any> = T | Promise<T>;

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -158,10 +158,10 @@ export function getRequestIP(
      *
      * Note: This is easily spoofed, make sure that this header can be trusted before enabling.
      */
-    xForwardedFor?: boolean
+    xForwardedFor?: boolean;
   } = {},
 ) {
-  const nonProxyIp = event.context.clientAddress
+  const nonProxyIp = event.context.clientAddress;
 
   if (!opts.xForwardedFor) {
     return nonProxyIp;

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -160,15 +160,21 @@ export function getRequestIP(
      */
     xForwardedFor?: boolean;
   } = {},
-) {
-  const nonProxyIp = event.context.clientAddress;
-
-  if (!opts.xForwardedFor) {
-    return nonProxyIp;
+): string | undefined {
+  if (event.context.clientAddress) {
+    return event.context.clientAddress;
   }
 
-  const xForwardedFor = getRequestHeader(event, "x-forwarded-for")
-    ?.split(",")
-    ?.pop();
-  return xForwardedFor || nonProxyIp;
+  if (opts.xForwardedFor) {
+    const xForwardedFor = getRequestHeader(event, "x-forwarded-for")
+      ?.split(",")
+      ?.pop();
+    if (xForwardedFor) {
+      return xForwardedFor;
+    }
+  }
+
+  if (event.node.req.socket.remoteAddress) {
+    return event.node.req.socket.remoteAddress;
+  }
 }

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -154,14 +154,15 @@ export function getRequestIP(
   event: H3Event,
   opts: { xForwardedFor?: boolean } = {},
 ) {
-  const ip = (event.node.req.connection as any).remoteAddress;
+  const nonProxyIp = (event.node.req.connection as any).remoteAddress;
 
   if (!opts.xForwardedFor) {
-    return ip;
+    return nonProxyIp;
   }
 
   const xForwardedFor = getRequestHeader(event, "x-forwarded-for")
     ?.split(",")
     ?.pop()
-  return xForwardedFor || ip;
+  const ip = xForwardedFor || nonProxyIp;
+  return ip.split(':')[0]
 }

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -149,3 +149,19 @@ export function getRequestURL(
   const path = getRequestPath(event);
   return new URL(path, `${protocol}://${host}`);
 }
+
+export function getRequestIP(
+  event: H3Event,
+  opts: { xForwardedFor?: boolean } = {},
+) {
+  const ip = (event.node.req.connection as any).remoteAddress;
+
+  if (!opts.xForwardedFor) {
+    return ip;
+  }
+
+  const xForwardedFor = getRequestHeader(event, "x-forwarded-for")
+    ?.split(",")
+    ?.pop()
+  return xForwardedFor || ip;
+}

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -163,6 +163,5 @@ export function getRequestIP(
   const xForwardedFor = getRequestHeader(event, "x-forwarded-for")
     ?.split(",")
     ?.pop();
-  const ip = xForwardedFor || nonProxyIp;
-  return ip.split(":")[0];
+  return xForwardedFor || nonProxyIp;
 }

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -156,7 +156,7 @@ export function getRequestIP(
     /**
      * Use the X-Forwarded-For HTTP header set by proxies.
      *
-     * Note: This is easily spoofed, make sure that this header can be trusted before enabling.
+     * Note: Make sure that this header can be trusted (your application running behind a CDN or reverse proxy) before enabling.
      */
     xForwardedFor?: boolean;
   } = {},

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -162,7 +162,7 @@ export function getRequestIP(
 
   const xForwardedFor = getRequestHeader(event, "x-forwarded-for")
     ?.split(",")
-    ?.pop()
+    ?.pop();
   const ip = xForwardedFor || nonProxyIp;
-  return ip.split(':')[0]
+  return ip.split(":")[0];
 }

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -152,9 +152,16 @@ export function getRequestURL(
 
 export function getRequestIP(
   event: H3Event,
-  opts: { xForwardedFor?: boolean } = {},
+  opts: {
+    /**
+     * Use the X-Forwarded-For HTTP header set by proxies.
+     *
+     * Note: This is easily spoofed, make sure that this header can be trusted before enabling.
+     */
+    xForwardedFor?: boolean
+  } = {},
 ) {
-  const nonProxyIp = (event.node.req.connection as any).remoteAddress;
+  const nonProxyIp = event.context.clientAddress
 
   if (!opts.xForwardedFor) {
     return nonProxyIp;

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -146,7 +146,7 @@ describe("", () => {
   });
 
   describe("getRequestIP", () => {
-    it("getRequestIP:x-forwarded-for", async () => {
+    it("x-forwarded-for", async () => {
       app.use(
         "/",
         eventHandler((event) => {
@@ -157,6 +157,19 @@ describe("", () => {
       );
       const req = request.get("/");
       req.set("x-forwarded-for", "127.0.0.1");
+      expect((await req).text).toBe("127.0.0.1");
+    });
+    it("ports", async () => {
+      app.use(
+        "/",
+        eventHandler((event) => {
+          return getRequestIP(event, {
+            xForwardedFor: true,
+          });
+        }),
+      );
+      const req = request.get("/");
+      req.set("x-forwarded-for", "127.0.0.1:1234");
       expect((await req).text).toBe("127.0.0.1");
     });
   });

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -170,7 +170,20 @@ describe("", () => {
       );
       const req = request.get("/");
       req.set("x-forwarded-for", "127.0.0.1:1234");
-      expect((await req).text).toBe("127.0.0.1");
+      expect((await req).text).toBe("127.0.0.1:1234");
+    });
+    it("ipv6", async () => {
+      app.use(
+        "/",
+        eventHandler((event) => {
+          return getRequestIP(event, {
+            xForwardedFor: true,
+          });
+        }),
+      );
+      const req = request.get("/");
+      req.set("x-forwarded-for", "2001:0db8:85a3:0000:0000:8a2e:0370:7334");
+      expect((await req).text).toBe("2001:0db8:85a3:0000:0000:8a2e:0370:7334");
     });
   });
 

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -11,6 +11,7 @@ import {
   getQuery,
   getRequestURL,
   readFormData,
+  getRequestIP,
 } from "../src";
 
 describe("", () => {
@@ -142,6 +143,22 @@ describe("", () => {
         expect((await req).text).toBe(JSON.stringify(test.url));
       });
     }
+  });
+
+  describe("getRequestIP", () => {
+    it("getRequestIP:x-forwarded-for", async () => {
+      app.use(
+        "/",
+        eventHandler((event) => {
+          return getRequestIP(event, {
+            xForwardedFor: true,
+          });
+        }),
+      );
+      const req = request.get("/");
+      req.set("x-forwarded-for", "127.0.0.1");
+      expect((await req).text).toBe("127.0.0.1");
+    });
   });
 
   describe("assertMethod", () => {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
https://github.com/unjs/h3/issues/272

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

We should make it convenient for users to get the client request ip while being able to opt-in to trust the x-forwarded-for header.

Currently, users are implementing themselves:
- https://github.com/Baroshem/nuxt-security/blob/main/src/runtime/server/middleware/rateLimiter.ts#L7C14-L7C30
- https://github.com/timb-103/nuxt-rate-limit/blob/master/src/runtime/server/utils/rate-limit.ts#L81

I'm also open to naming this `getClientIp` or `getRequestClientIp`.

This utility does open the door for trusting spoofable headers (see nuxt-security), sorting that is out of the scope of this utility, I'll open this as a seperate issue.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
