### PR TITLE
refactor: cleanup event interface

### DIFF
--- a/src/adapters/plain.ts
+++ b/src/adapters/plain.ts
@@ -5,6 +5,7 @@ import type { HTTPMethod } from "../types";
 import { createError, isError, sendError } from "../error";
 import { H3Event, createEvent, eventHandler } from "../event";
 import {
+  getRequestWebStream,
   setResponseHeader,
   setResponseStatus,
   splitCookiesString,
@@ -44,7 +45,7 @@ export function fromPlainHandler(handler: PlainHandler) {
       method: event.method,
       path: event.path,
       headers: Object.fromEntries(event.headers.entries()),
-      body: event.rawBody,
+      body: getRequestWebStream(event),
       context: event.context,
     });
     setResponseStatus(event, res.status, res.statusText);

--- a/src/adapters/plain.ts
+++ b/src/adapters/plain.ts
@@ -83,7 +83,7 @@ export async function _handlePlainRequest(app: App, request: PlainRequest) {
   event._path = path;
   event._headers = headers;
   if (request.body) {
-    event._body = request.body;
+    event._requestBody = request.body;
   }
   if (request._eventOverrides) {
     Object.assign(event, request._eventOverrides);

--- a/src/adapters/web.ts
+++ b/src/adapters/web.ts
@@ -1,7 +1,7 @@
 import type { App } from "../app";
 import { eventHandler } from "../event";
+import { toWebRequest } from "../utils";
 import { _handlePlainRequest } from "./plain";
-import { toWebRequest } from "src/utils";
 
 /** @experimental */
 export type WebHandler = (

--- a/src/adapters/web.ts
+++ b/src/adapters/web.ts
@@ -1,6 +1,7 @@
 import type { App } from "../app";
 import { eventHandler } from "../event";
 import { _handlePlainRequest } from "./plain";
+import { toWebRequest } from "src/utils";
 
 /** @experimental */
 export type WebHandler = (
@@ -19,7 +20,7 @@ export function toWebHandler(app: App) {
 
 /** @experimental */
 export function fromWebHandler(handler: WebHandler) {
-  return eventHandler((event) => handler(event.request, event.context));
+  return eventHandler((event) => handler(toWebRequest(event), event.context));
 }
 
 // --- Internal ---
@@ -34,8 +35,7 @@ async function _handleWebRequest(
   const url = new URL(request.url);
   const res = await _handlePlainRequest(app, {
     _eventOverrides: {
-      _request: request,
-      _url: url,
+      web: { request, url },
     },
     context,
     method: request.method,

--- a/src/event/event.ts
+++ b/src/event/event.ts
@@ -3,14 +3,6 @@ import type { H3EventContext, HTTPMethod, EventHandlerRequest } from "../types";
 import type { NodeIncomingMessage, NodeServerResponse } from "../adapters/node";
 import { sendWebResponse } from "../utils";
 
-// TODO: Dedup from body.ts
-const PayloadMethods: Set<HTTPMethod> = new Set([
-  "PATCH",
-  "POST",
-  "PUT",
-  "DELETE",
-]);
-
 export interface NodeEventContext {
   req: NodeIncomingMessage & { originalUrl?: string };
   res: NodeServerResponse;
@@ -34,10 +26,10 @@ export class H3Event<
   context: H3EventContext = {}; // Shared
 
   // Request
-  _method: HTTPMethod | undefined;
-  _path: string | undefined;
-  _headers: Headers | undefined;
-  _body: null | BodyInit | undefined;
+  _method?: HTTPMethod;
+  _path?: string;
+  _headers?: Headers;
+  _requestBody?: BodyInit;
 
   // Response
   _handled = false;

--- a/src/event/event.ts
+++ b/src/event/event.ts
@@ -1,7 +1,7 @@
 import type { IncomingHttpHeaders } from "node:http";
 import type { H3EventContext, HTTPMethod, EventHandlerRequest } from "../types";
 import type { NodeIncomingMessage, NodeServerResponse } from "../adapters/node";
-import { getRequestURL, sendWebResponse } from "../utils";
+import { sendWebResponse } from "../utils";
 
 // TODO: Dedup from body.ts
 const PayloadMethods: Set<HTTPMethod> = new Set([
@@ -16,6 +16,11 @@ export interface NodeEventContext {
   res: NodeServerResponse;
 }
 
+export interface WebEventContext {
+  request?: Request;
+  url?: URL;
+}
+
 export class H3Event<
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   _RequestT extends EventHandlerRequest = EventHandlerRequest,
@@ -24,16 +29,15 @@ export class H3Event<
   "__is_event__" = true;
 
   // Context
-  node: NodeEventContext;
-  context: H3EventContext = {};
+  node: NodeEventContext; // Node
+  web?: WebEventContext; // Web
+  context: H3EventContext = {}; // Shared
 
   // Request
-  _request: Request | undefined;
   _method: HTTPMethod | undefined;
-  _headers: Headers | undefined;
   _path: string | undefined;
-  _url: URL | undefined;
-  _body: BodyInit | undefined;
+  _headers: Headers | undefined;
+  _body: null | BodyInit | undefined;
 
   // Response
   _handled = false;
@@ -42,30 +46,7 @@ export class H3Event<
     this.node = { req, res };
   }
 
-  get _originalPath() {
-    return this.node.req.originalUrl || this.node.req.url || "/";
-  }
-
-  get _hasBody() {
-    return PayloadMethods.has(this.method!);
-  }
-
-  get path() {
-    return this._path || this.node.req.url || "/";
-  }
-
-  get url() {
-    if (!this._url) {
-      this._url = getRequestURL(this);
-    }
-    return this._url;
-  }
-
-  get handled(): boolean {
-    return (
-      this._handled || this.node.res.writableEnded || this.node.res.headersSent
-    );
-  }
+  // --- Request ---
 
   get method(): HTTPMethod {
     if (!this._method) {
@@ -76,12 +57,42 @@ export class H3Event<
     return this._method;
   }
 
+  get path() {
+    return this._path || this.node.req.url || "/";
+  }
+
   get headers(): Headers {
     if (!this._headers) {
       this._headers = _normalizeNodeHeaders(this.node.req.headers);
     }
     return this._headers;
   }
+
+  // --- Respoonse ---
+
+  get handled(): boolean {
+    return (
+      this._handled || this.node.res.writableEnded || this.node.res.headersSent
+    );
+  }
+
+  respondWith(response: Response | PromiseLike<Response>): Promise<void> {
+    return Promise.resolve(response).then((_response) =>
+      sendWebResponse(this, _response),
+    );
+  }
+
+  // --- Utils ---
+
+  toString() {
+    return `[${this.method}] ${this.path}`;
+  }
+
+  toJSON() {
+    return this.toString();
+  }
+
+  // --- Deprecated ---
 
   /** @deprecated Please use `event.node.req` instead. **/
   get req() {
@@ -91,57 +102,6 @@ export class H3Event<
   /** @deprecated Please use `event.node.res` instead. **/
   get res() {
     return this.node.res;
-  }
-
-  /** @experimental */
-  get rawBody() {
-    if (!this._hasBody) {
-      return undefined;
-    }
-    if (this._body === undefined) {
-      this._body = new ReadableStream({
-        start: (controller) => {
-          this.node.req.on("data", (chunk) => {
-            controller.enqueue(chunk);
-          });
-          this.node.req.on("end", () => {
-            controller.close();
-          });
-          this.node.req.on("error", (err) => {
-            controller.error(err);
-          });
-        },
-      });
-    }
-    return this._body;
-  }
-
-  /** @experimental */
-  get request(): Request {
-    if (!this._request) {
-      this._request = new Request(this.url, {
-        // @ts-ignore Undici option
-        duplex: "half",
-        method: this.method,
-        headers: this.headers,
-        body: this.rawBody,
-      });
-    }
-    return this._request;
-  }
-
-  respondWith(response: Response | PromiseLike<Response>): Promise<void> {
-    return Promise.resolve(response).then((_response) =>
-      sendWebResponse(this, _response),
-    );
-  }
-
-  toString() {
-    return `[${this.method}] ${this.url}`;
-  }
-
-  toJSON() {
-    return this.toString();
   }
 }
 

--- a/src/utils/body.ts
+++ b/src/utils/body.ts
@@ -193,6 +193,7 @@ export function getRequestWebStream(
   }
   return (
     event.web?.request?.body ||
+    (event._requestBody as ReadableStream) ||
     new ReadableStream({
       start: (controller) => {
         event.node.req.on("data", (chunk) => {

--- a/src/utils/body.ts
+++ b/src/utils/body.ts
@@ -35,7 +35,7 @@ export function readRawBody<E extends Encoding = "utf8">(
 
   // Reuse body if already read
   const _rawBody =
-    event._body ||
+    event._requestBody ||
     (event.node.req as any)[RawBodySymbol] ||
     (event.node.req as any).body; /* unjs/unenv #8 */
   if (_rawBody) {
@@ -185,7 +185,12 @@ export async function readFormData(event: H3Event) {
   return await toWebRequest(event).formData();
 }
 
-export function getRequestWebStream(event: H3Event): ReadableStream {
+export function getRequestWebStream(
+  event: H3Event,
+): undefined | ReadableStream {
+  if (!PayloadMethods.includes(event.method)) {
+    return;
+  }
   return (
     event.web?.request?.body ||
     new ReadableStream({

--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -3,7 +3,7 @@ import type { H3EventContext, RequestHeaders } from "../types";
 import { getRequestHeaders } from "./request";
 import { splitCookiesString } from "./cookie";
 import { sanitizeStatusMessage, sanitizeStatusCode } from "./sanitize";
-import { readRawBody } from "./body";
+import { getRequestWebStream, readRawBody } from "./body";
 
 export type Duplex = "half" | "full";
 
@@ -40,7 +40,7 @@ export async function proxyRequest(
   let duplex: Duplex | undefined;
   if (PayloadMethods.has(event.method)) {
     if (opts.streamRequest) {
-      body = event.rawBody;
+      body = getRequestWebStream(event);
       duplex = "half";
     } else {
       body = await readRawBody(event, false).catch(() => undefined);

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -129,8 +129,11 @@ export function getRequestProtocol(
   return (event.node.req.connection as any).encrypted ? "https" : "http";
 }
 
+const DOUBLE_SLASH_RE = /[/\\]{2,}/g;
+/** @deprecated Use `event.path` instead */
 export function getRequestPath(event: H3Event): string {
-  return (event.node.req.originalUrl || event.path).replace(/^[/\\]+/g, "/");
+  const path = (event.node.req.url || "/").replace(DOUBLE_SLASH_RE, "/");
+  return path;
 }
 
 export function getRequestURL(

--- a/test/plain.test.ts
+++ b/test/plain.test.ts
@@ -5,6 +5,7 @@ import {
   toPlainHandler,
   PlainHandler,
   eventHandler,
+  readBody,
 } from "../src";
 
 describe("Plain handler", () => {
@@ -21,7 +22,7 @@ describe("Plain handler", () => {
       "/test",
       eventHandler(async (event) => {
         const body =
-          event.method === "POST" ? await event.request.text() : undefined;
+          event.method === "POST" ? await readBody(event) : undefined;
         event.node.res.statusCode = 201;
         event.node.res.statusMessage = "Created";
         event.node.res.setHeader("content-type", "application/json");

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -99,7 +99,7 @@ describe("", () => {
     const tests = [
       { path: "/foo", url: "http://127.0.0.1/foo" },
       { path: "//foo", url: "http://127.0.0.1/foo" },
-      { path: "//foo.com//bar", url: "http://127.0.0.1/foo.com/bar" },
+      { path: "//foo.com//bar", url: "http://127.0.0.1/foo.com//bar" },
       { path: "///foo", url: "http://127.0.0.1/foo" },
       { path: "\\foo", url: "http://127.0.0.1/foo" },
       { path: "\\\\foo", url: "http://127.0.0.1/foo" },

--- a/test/web.test.ts
+++ b/test/web.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { createApp, App, eventHandler, WebHandler, toWebHandler } from "../src";
+import {
+  createApp,
+  App,
+  eventHandler,
+  WebHandler,
+  toWebHandler,
+  readBody,
+} from "../src";
 
 describe("Web handler", () => {
   let app: App;
@@ -15,7 +22,7 @@ describe("Web handler", () => {
       "/test",
       eventHandler(async (event) => {
         const body =
-          event.method === "POST" ? await event.request.text() : undefined;
+          event.method === "POST" ? await readBody(event) : undefined;
         event.node.res.statusCode = 201;
         event.node.res.statusMessage = "Created";
         return {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Before releasing h3 1.8, this PR makes sure we minimize new interface changes and chances of future possible breaking changes.

Meanwhile, I was trying new Web APIs, and figured it is so easy to shoot in the foot by runtime expensive getters such as `event.url` or `event.request` (did myself ironically!). Composable utils are a little bit more verbose to use but also easy to replace or deprecate.

Changes from the last RC:

- Move `event.rawBody` to `getRequestWebStream(event)`
- Move `event.request` to `toWebRequest(event)`
- Move top-level web context to `event.web?` (`WebEventContext = { request, url }`)
- Drop `event._originalPath` internal getter
- Drop `event._hasBody` internal getter
- Move `event.url` to `getRequestURL(event)`
- Fixed an unseen issue with `readRawBody` and `readBody` to support web request body streams
- Simplify `getRequestPath` to only normalize trailing double slashes 
- Revert `getRequestPath` to 1.7.1 implementation and deprecate

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
