### PR TITLE
feat: `defineRequestMidleware`, `defineResponseMiddleware` and rename object synctax hooks

### DIFF
--- a/src/event/utils.ts
+++ b/src/event/utils.ts
@@ -88,13 +88,13 @@ async function _callHandler(
 
 export const eventHandler = defineEventHandler;
 
-export function define_RequestMiddleware<
+export function defineRequestMiddleware<
   Request extends EventHandlerRequest = EventHandlerRequest,
 >(fn: _RequestMiddleware<Request>): _RequestMiddleware<Request> {
   return fn;
 }
 
-export function define_ResponseMiddleware<
+export function defineResponseMiddleware<
   Request extends EventHandlerRequest = EventHandlerRequest,
 >(fn: _ResponseMiddleware<Request>): _ResponseMiddleware<Request> {
   return fn;

--- a/src/event/utils.ts
+++ b/src/event/utils.ts
@@ -91,17 +91,13 @@ export const eventHandler = defineEventHandler;
 export function defineRequestMiddleware<
   Request extends EventHandlerRequest = EventHandlerRequest,
 >(fn: RequestMiddleware<Request>): RequestMiddleware<Request> {
-  return async (event: H3Event<Request>) => {
-    await fn(event);
-  };
+  return fn;
 }
 
 export function defineResponseMiddleware<
   Request extends EventHandlerRequest = EventHandlerRequest,
 >(fn: ResponseMiddleware<Request>): ResponseMiddleware<Request> {
-  return async (event, response) => {
-    await fn(event, response);
-  };
+  return fn;
 }
 
 export function isEventHandler(input: any): input is EventHandler {

--- a/src/event/utils.ts
+++ b/src/event/utils.ts
@@ -4,14 +4,14 @@ import type {
   EventHandlerRequest,
   EventHandlerResponse,
   EventHandlerObject,
-  RequestMiddleware,
-  ResponseMiddleware,
+  _RequestMiddleware,
+  _ResponseMiddleware,
 } from "../types";
 import type { H3Event } from "./event";
 
 type _EventHandlerHooks = {
-  onRequest?: RequestMiddleware[];
-  beforeResponse?: ResponseMiddleware[];
+  onRequest?: _RequestMiddleware[];
+  beforeResponse?: _ResponseMiddleware[];
 };
 
 export function defineEventHandler<
@@ -88,15 +88,15 @@ async function _callHandler(
 
 export const eventHandler = defineEventHandler;
 
-export function defineRequestMiddleware<
+export function define_RequestMiddleware<
   Request extends EventHandlerRequest = EventHandlerRequest,
->(fn: RequestMiddleware<Request>): RequestMiddleware<Request> {
+>(fn: _RequestMiddleware<Request>): _RequestMiddleware<Request> {
   return fn;
 }
 
-export function defineResponseMiddleware<
+export function define_ResponseMiddleware<
   Request extends EventHandlerRequest = EventHandlerRequest,
->(fn: ResponseMiddleware<Request>): ResponseMiddleware<Request> {
+>(fn: _ResponseMiddleware<Request>): _ResponseMiddleware<Request> {
   return fn;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -71,11 +71,11 @@ export interface EventHandler<
   (event: H3Event<Request>): Response;
 }
 
-export type RequestMiddleware<
+export type _RequestMiddleware<
   Request extends EventHandlerRequest = EventHandlerRequest,
 > = (event: H3Event<Request>) => void | Promise<void>;
 
-export type ResponseMiddleware<
+export type _ResponseMiddleware<
   Request extends EventHandlerRequest = EventHandlerRequest,
   Response extends EventHandlerResponse = EventHandlerResponse,
 > = (
@@ -87,10 +87,10 @@ export type EventHandlerObject<
   Request extends EventHandlerRequest = EventHandlerRequest,
   Response extends EventHandlerResponse = EventHandlerResponse,
 > = {
-  onRequest?: RequestMiddleware<Request> | RequestMiddleware<Request>[];
+  onRequest?: _RequestMiddleware<Request> | _RequestMiddleware<Request>[];
   beforeResponse?:
-    | ResponseMiddleware<Request, Response>
-    | ResponseMiddleware<Request, Response>[];
+    | _ResponseMiddleware<Request, Response>
+    | _ResponseMiddleware<Request, Response>[];
   handler: EventHandler<Request, Response>;
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -71,16 +71,27 @@ export interface EventHandler<
   (event: H3Event<Request>): Response;
 }
 
+export type RequestMiddleware<
+  Request extends EventHandlerRequest = EventHandlerRequest,
+> = (event: H3Event<Request>) => void | Promise<void>;
+
+export type ResponseMiddleware<
+  Request extends EventHandlerRequest = EventHandlerRequest,
+  Response extends EventHandlerResponse = EventHandlerResponse,
+> = (
+  event: H3Event<Request>,
+  response: { body?: Awaited<Response> },
+) => void | Promise<void>;
+
 export type EventHandlerObject<
   Request extends EventHandlerRequest = EventHandlerRequest,
   Response extends EventHandlerResponse = EventHandlerResponse,
 > = {
+  onRequest?: RequestMiddleware<Request> | RequestMiddleware<Request>[];
+  beforeResponse?:
+    | ResponseMiddleware<Request, Response>
+    | ResponseMiddleware<Request, Response>[];
   handler: EventHandler<Request, Response>;
-  before?: ((event: H3Event<Request>) => void | Promise<void>)[];
-  after?: ((
-    event: H3Event<Request>,
-    response: { body?: Response },
-  ) => void | Promise<void>)[];
 };
 
 export type LazyEventHandler = () => EventHandler | Promise<EventHandler>;

--- a/test/types.test-d.ts
+++ b/test/types.test-d.ts
@@ -13,7 +13,7 @@ describe("types", () => {
   describe("eventHandler", () => {
     it("object syntax definitions", async () => {
       const handler = eventHandler({
-        before: [
+        onRequest: [
           (event) => {
             expectTypeOf(event).toEqualTypeOf<H3Event>();
           },


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

Context: Find most of DX issues while working on a example for https://github.com/unjs/h3/issues/501

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR introduces two new define utils `defineRequestMidleware` and `defineResponseMiddleware` (with `RequestMiddleware` and `ResponseMiddleware`) types.

These utils are then used for event handlers with object syntax but can also used independently to define such hooks outside of the event handler in a composable way (imagine `compressionMiddleware` as util)

Also in order to keep consistency with global hook options and readability, the hooks are renamed from `before`/`after` to `onRequest`/`beforeResponse`.

Also we support non Array format for most consistency with top level

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
