### PR TITLE
fix: send original Error to custom error handlers instead of H3Error

### DIFF
--- a/src/adapters/node.ts
+++ b/src/adapters/node.ts
@@ -63,7 +63,7 @@ export function toNodeListener(app: App): NodeListener {
       }
 
       if (app.options.onError) {
-        await app.options.onError(error, event);
+        await app.options.onError(_error, event);
       }
       if (event.handled) {
         return;

--- a/src/adapters/plain.ts
+++ b/src/adapters/plain.ts
@@ -101,7 +101,7 @@ export async function _handlePlainRequest(app: App, request: PlainRequest) {
       error.unhandled = true;
     }
     if (app.options.onError) {
-      await app.options.onError(error, event);
+      await app.options.onError(_error, event);
     }
     if (!event.handled) {
       if (error.unhandled || error.fatal) {

--- a/src/app.ts
+++ b/src/app.ts
@@ -49,7 +49,7 @@ export interface AppUse {
 
 export interface AppOptions {
   debug?: boolean;
-  onError?: (error: H3Error, event: H3Event) => any;
+  onError?: (error: Error, event: H3Event) => any;
   onRequest?: (event: H3Event) => void | Promise<void>;
   onBeforeResponse?: (
     event: H3Event,


### PR DESCRIPTION
### 🔗 Linked issue

#517

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [X] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [X] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The custom errorHandler option currently gets passed a `H3Error` instead of the original `Error` in order for the
custom errorHandler to handle specific errors it should get passed the original `error`. This PR fixes this.
Resolves #517

This could break currently existing errorHandlers that expect an H3Error to be passed. Those can be fixed very easily by
calling `createError(error)`

### 📝 Checklist

- [X] I have linked an issue or discussion.
- [X] I have updated the documentation accordingly. _(not applicable)_
