### PR TITLE
fix: use safe property checks

### DIFF
--- a/src/error.ts
+++ b/src/error.ts
@@ -5,6 +5,7 @@ import {
   sanitizeStatusMessage,
   sanitizeStatusCode,
 } from "./utils";
+import { hasProp } from "./utils/internal/object";
 
 /**
  * H3 Runtime Error
@@ -78,7 +79,7 @@ export function createError(
     cause: input.cause || input,
   });
 
-  if ("stack" in input) {
+  if (hasProp(input, "stack")) {
     try {
       Object.defineProperty(err, "stack", {
         get() {

--- a/src/event/event.ts
+++ b/src/event/event.ts
@@ -2,6 +2,7 @@ import type { IncomingHttpHeaders } from "node:http";
 import type { H3EventContext, HTTPMethod, EventHandlerRequest } from "../types";
 import type { NodeIncomingMessage, NodeServerResponse } from "../adapters/node";
 import { sendWebResponse } from "../utils";
+import { hasProp } from "../utils/internal/object";
 
 export interface NodeEventContext {
   req: NodeIncomingMessage & { originalUrl?: string };
@@ -98,7 +99,7 @@ export class H3Event<
 }
 
 export function isEvent(input: any): input is H3Event {
-  return Object.hasOwnProperty.call(input, "__is_event__");
+  return hasProp(input, "__is_event__");
 }
 
 export function createEvent(

--- a/src/event/event.ts
+++ b/src/event/event.ts
@@ -98,7 +98,7 @@ export class H3Event<
 }
 
 export function isEvent(input: any): input is H3Event {
-  return "__is_event__" in input;
+  return Object.hasOwnProperty.call(input, "__is_event__");
 }
 
 export function createEvent(

--- a/src/event/utils.ts
+++ b/src/event/utils.ts
@@ -8,6 +8,7 @@ import type {
   _ResponseMiddleware,
 } from "../types";
 import type { H3Event } from "./event";
+import { hasProp } from "src/utils/internal/object";
 
 type _EventHandlerHooks = {
   onRequest?: _RequestMiddleware[];
@@ -101,7 +102,7 @@ export function defineResponseMiddleware<
 }
 
 export function isEventHandler(input: any): input is EventHandler {
-  return "__is_handler__" in input;
+  return hasProp(input, "__is_handler__");
 }
 
 export function toEventHandler(

--- a/src/event/utils.ts
+++ b/src/event/utils.ts
@@ -7,8 +7,8 @@ import type {
   _RequestMiddleware,
   _ResponseMiddleware,
 } from "../types";
+import { hasProp } from "../utils/internal/object";
 import type { H3Event } from "./event";
-import { hasProp } from "src/utils/internal/object";
 
 type _EventHandlerHooks = {
   onRequest?: _RequestMiddleware[];

--- a/src/utils/body.ts
+++ b/src/utils/body.ts
@@ -6,6 +6,7 @@ import { createError } from "../error";
 import { parse as parseMultipartData } from "./internal/multipart";
 import { assertMethod, getRequestHeader, toWebRequest } from "./request";
 import { ValidateFunction, validateData } from "./internal/validate";
+import { hasProp } from "./internal/object";
 
 export type { MultiPartData } from "./internal/multipart";
 
@@ -132,7 +133,7 @@ export async function readBody<
   _T = InferEventInput<"body", Event, T>,
 >(event: Event, options: { strict?: boolean } = {}): Promise<_T> {
   const request = event.node.req as InternalRequest<T>;
-  if (ParsedBodySymbol in request) {
+  if (hasProp(request, ParsedBodySymbol)) {
     return request[ParsedBodySymbol] as _T;
   }
 
@@ -244,7 +245,7 @@ function _parseURLEncodedBody(body: string) {
   const form = new URLSearchParams(body);
   const parsedForm: Record<string, any> = Object.create(null);
   for (const [key, value] of form.entries()) {
-    if (key in parsedForm) {
+    if (hasProp(parsedForm, key)) {
       if (!Array.isArray(parsedForm[key])) {
         parsedForm[key] = [parsedForm[key]];
       }

--- a/src/utils/internal/object.ts
+++ b/src/utils/internal/object.ts
@@ -1,3 +1,8 @@
-export function hasProp(obj: any, prop: string | symbol) {
-  return Object.prototype.hasOwnProperty.call(obj, prop);
+export function hasProp(obj: object, prop: string | symbol) {
+  // TODO: Benchmark typeof vs try/catch (i guess try catch is faster in non-edge cases!)
+  try {
+    return prop in obj;
+  } catch {
+    return false;
+  }
 }

--- a/src/utils/internal/object.ts
+++ b/src/utils/internal/object.ts
@@ -1,5 +1,5 @@
 export function hasProp(obj: object, prop: string | symbol) {
-  // TODO: Benchmark typeof vs try/catch (i guess try catch is faster in non-edge cases!)
+  // TODO: Benchmark typeof vs try/catch (i guess try/catch is faster in non-edge cases!)
   try {
     return prop in obj;
   } catch {

--- a/src/utils/internal/object.ts
+++ b/src/utils/internal/object.ts
@@ -1,5 +1,5 @@
+// TODO: Benchmark typeof vs try/catch (i guess try/catch is faster in non-edge cases!)
 export function hasProp(obj: object, prop: string | symbol) {
-  // TODO: Benchmark typeof vs try/catch (i guess try/catch is faster in non-edge cases!)
   try {
     return prop in obj;
   } catch {

--- a/src/utils/internal/object.ts
+++ b/src/utils/internal/object.ts
@@ -1,0 +1,3 @@
+export function hasProp(obj: any, prop: string | symbol) {
+  return Object.prototype.hasOwnProperty.call(obj, prop);
+}


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

Ref https://github.com/unjs/nitro/pull/1637

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`in` operator expects the right hand to be an Object and can easily lead to edge case issues when we check something like `'foo' in 2` > `Uncaught TypeError: Cannot use 'in' operator to search for 'foo' in 2`.

This PR uses a small shared util for safer checks.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
