### PR TITLE
fix(getRequestProtocol): conditionaly check `connection?.encrypted`

### DIFF
--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -126,7 +126,7 @@ export function getRequestProtocol(
   ) {
     return "https";
   }
-  return (event.node.req.connection as any).encrypted ? "https" : "http";
+  return (event.node.req.connection as any)?.encrypted ? "https" : "http";
 }
 
 const DOUBLE_SLASH_RE = /[/\\]{2,}/g;


### PR DESCRIPTION
fix: add optional chain (.?) to event connection check in getRequestProtocol

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [X] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

A minor change, but essentially if event.node.req.connection is undefined ... we can't check for the encrypted boolean value, therefore an optional chain has been added.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
