### PR TITLE
types: add generics to `H3Error` data and `createError`

### DIFF
--- a/src/error.ts
+++ b/src/error.ts
@@ -40,7 +40,7 @@ export class H3Error<DataT = any> extends Error {
 
   toJSON() {
     const obj: Pick<
-      H3Error,
+      H3Error<DataT>,
       "message" | "statusCode" | "statusMessage" | "data"
     > = {
       message: this.message,

--- a/src/error.ts
+++ b/src/error.ts
@@ -65,7 +65,9 @@ export class H3Error<DataT = any> extends Error {
  * @return {H3Error} - An instance of H3Error.
  */
 export function createError<DataT = any>(
-  input: string | (Partial<H3Error<DataT>> & { status?: number; statusText?: string }),
+  input:
+    | string
+    | (Partial<H3Error<DataT>> & { status?: number; statusText?: string }),
 ): H3Error {
   if (typeof input === "string") {
     return new H3Error<DataT>(input);

--- a/src/error.ts
+++ b/src/error.ts
@@ -64,18 +64,18 @@ export class H3Error<DataT = any> extends Error {
  * @param input {string | (Partial<H3Error> & { status?: number; statusText?: string })} - The error message or an object containing error properties.
  * @return {H3Error} - An instance of H3Error.
  */
-export function createError(
-  input: string | (Partial<H3Error> & { status?: number; statusText?: string }),
+export function createError<DataT = any>(
+  input: string | (Partial<H3Error<DataT>> & { status?: number; statusText?: string }),
 ): H3Error {
   if (typeof input === "string") {
-    return new H3Error(input);
+    return new H3Error<DataT>(input);
   }
 
   if (isError(input)) {
     return input;
   }
 
-  const err = new H3Error(input.message ?? input.statusMessage ?? "", {
+  const err = new H3Error<DataT>(input.message ?? input.statusMessage ?? "", {
     cause: input.cause || input,
   });
 

--- a/src/error.ts
+++ b/src/error.ts
@@ -15,17 +15,17 @@ import { hasProp } from "./utils/internal/object";
  * @property {string} statusMessage - A string representing the HTTP status message.
  * @property {boolean} fatal - Indicates if the error is a fatal error.
  * @property {boolean} unhandled - Indicates if the error was unhandled and auto captured.
- * @property {any} data - An extra data that will be included in the response.
+ * @property {DataT} data - An extra data that will be included in the response.
  *                         This can be used to pass additional information about the error.
  * @property {boolean} internal - Setting this property to `true` will mark the error as an internal error.
  */
-export class H3Error extends Error {
+export class H3Error<DataT = any> extends Error {
   static __h3_error__ = true;
   statusCode = 500;
   fatal = false;
   unhandled = false;
   statusMessage?: string;
-  data?: any;
+  data?: DataT;
   cause?: unknown;
 
   constructor(message: string, opts: { cause?: unknown } = {}) {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR allows for typed data property of the `H3Error` class with an optional generic param defaulting to `any`, which in turn can be used to provide typed data property on the `err` returned by `createError` function.


<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
