### PR TITLE
test(proxy): Add failing test for forwarding cookies with redirects

### DIFF
--- a/test/proxy.test.ts
+++ b/test/proxy.test.ts
@@ -245,36 +245,37 @@ describe("", () => {
 
     it("can proxy cookie on redirect", async () => {
       app.use(
-        "/debug",
+        "/a",
         eventHandler((event) => {
-          setCookie(event, "cookie", "success");
-          return sendRedirect(event, "/2debug");
+          setCookie(event, "cookie", "user-cookie");
+          return sendRedirect(event, "/b");
         }),
       );
 
       app.use(
-        "/2debug",
+        "/b",
         eventHandler((event) => {
           const cookieValue = getCookie(event, "cookie");
-          return cookieValue ?? "fail";
+          return cookieValue ?? "no-cookie";
         }),
       );
 
       app.use(
         "/",
         eventHandler((event) => {
-          return proxyRequest(event, url + "/debug", {
+          return proxyRequest(event, url + "/a", {
             fetch,
+            fetchOptions: { redirect: "manual" },
           });
         }),
       );
 
       const result = await request.get("/");
 
-      expect(result.text).toEqual("success");
+      expect(result.text).toContain("/b");
 
       const cookies = result.header["set-cookie"];
-      expect(cookies).toEqual(["cookie=success; Path=/"]);
+      expect(cookies).toEqual(["cookie=user-cookie; Path=/"]);
     });
   });
 


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Stumbled upon this testing redirects against https://httpbin.org/#/Cookies/.

The issue is two fold:
- the cookie is not forwarded to the client at all
- the cookie is not forwarded when fetching new location

Tbh I am not sure if such complex and niche scenario should be handled by the lib at all. One could use `{ redirect: 'manual' }` when `set-cookie` + redirect is expected and handle it in userland.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
