### PR TITLE
types: add generics to `isError` and update `DataT` default generic param

### DIFF
--- a/src/error.ts
+++ b/src/error.ts
@@ -19,7 +19,7 @@ import { hasProp } from "./utils/internal/object";
  *                         This can be used to pass additional information about the error.
  * @property {boolean} internal - Setting this property to `true` will mark the error as an internal error.
  */
-export class H3Error<DataT = any> extends Error {
+export class H3Error<DataT = unknown> extends Error {
   static __h3_error__ = true;
   statusCode = 500;
   fatal = false;
@@ -64,7 +64,7 @@ export class H3Error<DataT = any> extends Error {
  * @param input {string | (Partial<H3Error> & { status?: number; statusText?: string })} - The error message or an object containing error properties.
  * @return {H3Error} - An instance of H3Error.
  */
-export function createError<DataT = any>(
+export function createError<DataT = unknown>(
   input:
     | string
     | (Partial<H3Error<DataT>> & { status?: number; statusText?: string }),
@@ -177,6 +177,6 @@ export function sendError(
  * @param input {*} - The input to check.
  * @return {boolean} - Returns true if the input is an instance of H3Error, false otherwise.
  */
-export function isError<DataT = any>(input: any): input is H3Error<DataT> {
+export function isError<DataT = unknown>(input: any): input is H3Error<DataT> {
   return input?.constructor?.__h3_error__ === true;
 }

--- a/src/error.ts
+++ b/src/error.ts
@@ -68,12 +68,12 @@ export function createError<DataT = any>(
   input:
     | string
     | (Partial<H3Error<DataT>> & { status?: number; statusText?: string }),
-): H3Error {
+) {
   if (typeof input === "string") {
     return new H3Error<DataT>(input);
   }
 
-  if (isError(input)) {
+  if (isError<DataT>(input)) {
     return input;
   }
 
@@ -177,6 +177,6 @@ export function sendError(
  * @param input {*} - The input to check.
  * @return {boolean} - Returns true if the input is an instance of H3Error, false otherwise.
  */
-export function isError(input: any): input is H3Error {
+export function isError<DataT = any>(input: any): input is H3Error<DataT> {
   return input?.constructor?.__h3_error__ === true;
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Makes `isError` generic, hence removing the need to explictly annotate the return type of `createError`.

@pi0, shall we consider amending the default generic param for `DataT` from `any` to `unknown`, as per [this discussion](https://github.com/nuxt/nuxt/pull/24396#discussion_r1401272551)?

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
