### PR TITLE
types(setResponseHeaders): add autocompletion for header names

### DIFF
--- a/src/utils/response.ts
+++ b/src/utils/response.ts
@@ -107,7 +107,7 @@ export function getResponseHeader(
 
 export function setResponseHeaders(
   event: H3Event,
-  headers: Record<string, Parameters<OutgoingMessage["setHeader"]>[1]>,
+  headers: Record<HTTPHeaderName, Parameters<OutgoingMessage["setHeader"]>[1]>,
 ): void {
   for (const [name, value] of Object.entries(headers)) {
     event.node.res.setHeader(name, value);


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue
#542 
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
setResponseHeaders can also benefit from header autocompletion, so this PR adds it.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
