### PR TITLE
fix(readRawBody): check `req.rawBody` before `req.body`

### DIFF
--- a/src/utils/body.ts
+++ b/src/utils/body.ts
@@ -42,6 +42,7 @@ export function readRawBody<E extends Encoding = "utf8">(
     event._requestBody ||
     event.web?.request?.body ||
     (event.node.req as any)[RawBodySymbol] ||
+    (event.node.req as any).rawBody /* firebase */ ||
     (event.node.req as any).body; /* unjs/unenv #8 */
   if (_rawBody) {
     const promise = Promise.resolve(_rawBody).then((_resolved) => {


### PR DESCRIPTION

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

With `readRawBody` utility, we check `req.body` that can be provided from direct-fetch/unenv. (sadly) this conflicts with some runtimes (firebase) as I discovered which provides `req.body` as "parsed body".

Later we shall avoid depending on both and instead translate `rawBody` directly from higher-oder layers (user project or nitro preset entry for example) but this is a quick workaround for the situation.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
