### PR TITLE
fix(proxy): workaround undici issue with `DELETE` and content-length of 0

### DIFF
--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -57,6 +57,12 @@ export async function proxyRequest(
     opts.headers,
   );
 
+  // DELETE method must always have an empty object in the body, and a "content-length" header.
+  if (method === "DELETE" && body === undefined) {
+    body = Buffer.from("{}");
+    (fetchHeaders as { [key: string]: any })["content-length"] = 2;
+  }
+
   return sendProxy(event, target, {
     ...opts,
     fetchOptions: {

--- a/test/proxy.test.ts
+++ b/test/proxy.test.ts
@@ -240,6 +240,43 @@ describe("", () => {
 
       expect(resText).toEqual(message);
     });
+
+    it("can proxy DELETE request", async () => {
+      app.use(
+        "/delete",
+        eventHandler((event) => {
+          event.node.res.statusCode = 204;
+          return null;
+        }),
+      );
+
+      app.use(
+        "/",
+        eventHandler((event) => {
+          return proxyRequest(event, url + "/delete", { fetch });
+        }),
+      );
+
+      const result = await fetch(url + "/", {
+        method: "DELETE",
+      });
+      const { body, status, statusText } = result;
+      expect(status).toEqual(204);
+      expect(statusText).toEqual("No Content");
+      expect(body).toEqual(null);
+
+      const result2 = await fetch(url + "/", {
+        method: "DELETE",
+        body: Buffer.from("{}"),
+      });
+      expect(result2.status).toEqual(204);
+
+      const result3 = await fetch(url + "/", {
+        method: "DELETE",
+        body: null,
+      });
+      expect(result3.status).toEqual(204);
+    });
   });
 
   describe("multipleCookies", () => {


### PR DESCRIPTION
###  Linked issue

- #375
- https://github.com/nuxt/nuxt/issues/19325#issuecomment-1511440436_

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

###  Description

This pull request addresses the issue of proxy DELETE requests failing when no body or "content-length" header is present.

example error (this PR solves) when making a proxy DELETE request with nuxt3/nitro using h3:
``` typescript (nuxt.config)
export default defineNuxtConfig({
  routeRules: {
    '/api/**': { proxy: `${apiUrl}/**`},
  }
}
```

```bash
[nuxt] [request error] [unhandled] [500] fetch failed
  at Object.fetch (node:internal/deps/undici/undici:11372:11)  
  at process.processTicksAndRejections (node:internal/process/task_queues:95:5)  
  at async sendProxy (./node_modules/h3/dist/index.mjs:1084:20)  
  at async Object.handler (./node_modules/h3/dist/index.mjs:1680:19)  
  at async Server.toNodeHandle (./node_modules/h3/dist/index.mjs:1890:7)
```

**Fixes:**

- Ensures an empty body and "content-length" header for proxy DELETE requests.
- Adds tests to verify the fix.
- DELETE errors related to `async sendProxy (./node_modules/h3/dist/index.mjs)`

###  Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly. (Check this box if you've also made documentation changes)