### PR TITLE
fix(setResponseHeaders): fix types to allow partial header names

### DIFF
--- a/src/utils/response.ts
+++ b/src/utils/response.ts
@@ -107,10 +107,12 @@ export function getResponseHeader(
 
 export function setResponseHeaders(
   event: H3Event,
-  headers: Record<HTTPHeaderName, Parameters<OutgoingMessage["setHeader"]>[1]>,
+  headers: Partial<
+    Record<HTTPHeaderName, Parameters<OutgoingMessage["setHeader"]>[1]>
+  >,
 ): void {
   for (const [name, value] of Object.entries(headers)) {
-    event.node.res.setHeader(name, value);
+    event.node.res.setHeader(name, value!);
   }
 }
 


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/unjs/h3/pull/542
resolves https://github.com/unjs/h3/issues/614

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Currently, the record requires all keys to be set.
See: https://github.com/maevsi/maevsi/actions/runs/7428213670/job/20215223408

Adding `Partial` allows `value` to be `undefined` though. I guess the idea for undefined values would be to remove the corresponding header, but that change can be reverted of course!

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
