### PR TITLE
fix: avoid setting default `content-type` for responses with 304 status

### DIFF
--- a/src/utils/response.ts
+++ b/src/utils/response.ts
@@ -76,7 +76,11 @@ export function getResponseStatusText(event: H3Event): string {
 }
 
 export function defaultContentType(event: H3Event, type?: string) {
-  if (type && !event.node.res.getHeader("content-type")) {
+  if (
+    type &&
+    event.node.res.statusCode !== 304 /* unjs/h3#603 */ &&
+    !event.node.res.getHeader("content-type")
+  ) {
     event.node.res.setHeader("content-type", type);
   }
 }

--- a/test/status.test.ts
+++ b/test/status.test.ts
@@ -6,6 +6,7 @@ import {
   PlainHandler,
   eventHandler,
   setResponseStatus,
+  send,
 } from "../src";
 
 describe("setResponseStatus", () => {
@@ -105,6 +106,32 @@ describe("setResponseStatus", () => {
       expect(res).toMatchObject({
         status: 418,
         statusText: "status-text",
+        body: undefined,
+        headers: [],
+      });
+    });
+
+    it("does not sets content-type for 304", async () => {
+      app.use(
+        "/test",
+        eventHandler((event) => {
+          setResponseStatus(event, 304, "Not Modified");
+          return "";
+        }),
+      );
+
+      const res = await handler({
+        method: "GET",
+        path: "/test",
+        headers: [],
+        body: "",
+      });
+
+      console.log(res.headers);
+
+      expect(res).toMatchObject({
+        status: 304,
+        statusText: "Not Modified",
         body: undefined,
         headers: [],
       });


### PR DESCRIPTION
- test: add failing test
- fix: avoid setting default `content-type` for responses with 304 status

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

resolves #603

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
