### PR TITLE
fix(proxy): ignore incoming `accept` header

### DIFF
--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -28,6 +28,7 @@ const ignoredHeaders = new Set([
   "upgrade",
   "expect",
   "host",
+  "accept",
 ]);
 
 export async function proxyRequest(


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/24742
resolves https://github.com/nuxt/nuxt/issues/24609
resolves https://github.com/nuxt/nuxt/issues/23539

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This avoids proxying `accept` headers when fetching with event. Alternatively we could support an option via final argument to add additional headers to ignore, if you prefer.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
