### PR TITLE
fix(serveStatic): ensure `etag` header is set before sending 304 response

### DIFF
--- a/src/utils/static.ts
+++ b/src/utils/static.ts
@@ -115,6 +115,10 @@ export async function serveStatic(
     return false;
   }
 
+  if (meta.etag && !getResponseHeader(event, "etag")) {
+    setResponseHeader(event, "etag", meta.etag);
+  }
+
   const ifNotMatch =
     meta.etag && getRequestHeader(event, "if-none-match") === meta.etag;
   if (ifNotMatch) {
@@ -138,10 +142,6 @@ export async function serveStatic(
 
   if (meta.type && !getResponseHeader(event, "content-type")) {
     setResponseHeader(event, "content-type", meta.type);
-  }
-
-  if (meta.etag && !getResponseHeader(event, "etag")) {
-    setResponseHeader(event, "etag", meta.etag);
   }
 
   if (meta.encoding && !getResponseHeader(event, "content-encoding")) {

--- a/test/static.test.ts
+++ b/test/static.test.ts
@@ -83,6 +83,7 @@ describe("Serve Static", () => {
 
   it("Handles cache (if-none-match)", async () => {
     const res = await request.get("/test.png").set("if-none-match", "w/123");
+    expect(res.headers.etag).toBe(expectedHeaders.etag);
     expect(res.status).toEqual(304);
     expect(res.text).toBe("");
   });


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This is a small fix to ensure `ETag` header is set before sending `304` response: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/304
> The response [...] must include the headers that would have been sent in an equivalent 200 OK response: Cache-Control, Content-Location, Date, ETag, Expires, and Vary.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
