### PR TITLE
feat: handler resolver

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -3,6 +3,7 @@ import {
   toRouteMatcher,
   RouteMatcher,
 } from "radix3";
+import { withLeadingSlash } from "ufo";
 import type { HTTPMethod, EventHandler } from "./types";
 import { createError } from "./error";
 import { eventHandler, toEventHandler } from "./event";
@@ -82,10 +83,9 @@ export function createRouter(opts: CreateRouterOptions = {}): Router {
     router[method] = (path, handle) => router.add(path, handle, method);
   }
 
-  // Main handle
-  router.handler = eventHandler((event) => {
+  // Handler matcher
+  const matchHandler = (path = "/", method: RouterMethod = "get") => {
     // Remove query parameters for matching
-    let path = event.path || "/";
     const qIndex = path.indexOf("?");
     if (qIndex !== -1) {
       path = path.slice(0, Math.max(0, qIndex));
@@ -94,26 +94,20 @@ export function createRouter(opts: CreateRouterOptions = {}): Router {
     // Match route
     const matched = _router.lookup(path);
     if (!matched || !matched.handlers) {
-      if (opts.preemptive || opts.preemtive) {
-        throw createError({
+      return {
+        error: createError({
           statusCode: 404,
           name: "Not Found",
-          statusMessage: `Cannot find any route matching ${event.path || "/"}.`,
-        });
-      } else {
-        return; // Let app match other handlers
-      }
+          statusMessage: `Cannot find any route matching ${path || "/"}.`,
+        }),
+      };
     }
 
     // Match method
-    const method = (
-      event.node.req.method || "get"
-    ).toLowerCase() as RouterMethod;
-
     let handler: EventHandler | undefined =
       matched.handlers[method] || matched.handlers.all;
 
-    // Fallback to search for shadowed routes
+    // Fallback to search for (method) shadowed routes
     if (!handler) {
       if (!_matcher) {
         _matcher = toRouteMatcher(_router);
@@ -134,32 +128,63 @@ export function createRouter(opts: CreateRouterOptions = {}): Router {
       }
     }
 
-    // Method not matched
     if (!handler) {
-      if (opts.preemptive || opts.preemtive) {
-        throw createError({
+      return {
+        error: createError({
           statusCode: 405,
           name: "Method Not Allowed",
           statusMessage: `Method ${method} is not allowed on this route.`,
-        });
+        }),
+      };
+    }
+
+    return { matched, handler };
+  };
+
+  // Main handle
+  const isPreemptive = opts.preemptive || opts.preemtive;
+  router.handler = eventHandler((event) => {
+    // Match handler
+    const match = matchHandler(
+      event.path,
+      event.method.toLowerCase() as RouterMethod,
+    );
+
+    // No match (method or route)
+    if ("error" in match) {
+      if (isPreemptive) {
+        throw match.error;
       } else {
         return; // Let app match other handlers
       }
     }
 
     // Add matched route and params to the context
-    event.context.matchedRoute = matched;
-    const params = matched.params || {};
+    event.context.matchedRoute = match.matched;
+    const params = match.matched.params || {};
     event.context.params = params;
 
     // Call handler
-    return Promise.resolve(handler(event)).then((res) => {
-      if (res === undefined && (opts.preemptive || opts.preemtive)) {
+    return Promise.resolve(match.handler(event)).then((res) => {
+      if (res === undefined && isPreemptive) {
         return null; // Send empty content
       }
       return res;
     });
   });
+
+  // Resolver
+  router.handler.__resolve__ = (path) => {
+    path = withLeadingSlash(path);
+    const match = matchHandler(path);
+    if ("error" in match) {
+      return;
+    }
+    return {
+      route: match.matched.path,
+      handler: match.handler,
+    };
+  };
 
   return router;
 }

--- a/src/router.ts
+++ b/src/router.ts
@@ -174,16 +174,24 @@ export function createRouter(opts: CreateRouterOptions = {}): Router {
   });
 
   // Resolver
-  router.handler.__resolve__ = (path) => {
+  router.handler.__resolve__ = async (path) => {
     path = withLeadingSlash(path);
     const match = matchHandler(path);
     if ("error" in match) {
       return;
     }
-    return {
+    let res = {
       route: match.matched.path,
       handler: match.handler,
     };
+    if (match.handler.__resolve__) {
+      const _res = await match.handler.__resolve__(path);
+      if (!_res) {
+        return;
+      }
+      res = { ...res, ..._res };
+    }
+    return res;
   };
 
   return router;

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,11 +62,18 @@ export type InferEventInput<
   T,
 > = void extends T ? (Event extends H3Event<infer E> ? E[Key] : never) : T;
 
+type MaybePromise<T> = T | Promise<T>;
+
+export type EventHandlerResolver = (
+  path: string,
+) => MaybePromise<undefined | { route?: string; handler: EventHandler }>;
+
 export interface EventHandler<
   Request extends EventHandlerRequest = EventHandlerRequest,
   Response extends EventHandlerResponse = EventHandlerResponse,
 > {
   __is_handler__?: true;
+  __resolve__?: EventHandlerResolver;
   (event: H3Event<Request>): Response;
 }
 

--- a/test/resolve.test.ts
+++ b/test/resolve.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from "vitest";
+import { createApp, createRouter, eventHandler } from "../src";
+
+describe("Event handler resolver", () => {
+  const testHandlers = Array.from({ length: 10 }).map((_, i) =>
+    eventHandler(() => i),
+  );
+
+  const app = createApp();
+
+  const router = createRouter();
+  app.use(router);
+
+  // Middlware
+  app.use(testHandlers[0]);
+  app.use("/", testHandlers[1]);
+
+  // Path prefix
+  app.use("/test", testHandlers[2]);
+  app.use("/lazy", () => testHandlers[3], { lazy: true });
+
+  // Sub app
+  const app2 = createApp();
+  app.use("/foo", app2 as any);
+  app2.use("/bar", testHandlers[4]);
+
+  // Router
+  router.get("/router", testHandlers[5]);
+  router.get("/router/:id", testHandlers[6]);
+
+  describe("middleware", () => {
+    it("does not resolves /", async () => {
+      expect(await app.resolve("/")).toBeUndefined();
+    });
+  });
+
+  describe("path prefix", () => {
+    it("resolves /test", async () => {
+      expect(await app.resolve("/test")).toMatchObject({
+        route: "/test",
+        handler: testHandlers[2],
+      });
+    });
+
+    it("resolves /test/foo", async () => {
+      expect((await app.resolve("/test/foo"))?.route).toEqual("/test");
+    });
+  });
+
+  it("resolves /lazy", async () => {
+    expect(await app.resolve("/lazy")).toMatchObject({
+      route: "/lazy",
+      handler: testHandlers[3],
+    });
+  });
+
+  describe("nested app", () => {
+    it("resolves /foo/bar/baz", async () => {
+      expect(await app.resolve("/foo/bar/baz")).toMatchObject({
+        route: "/foo/bar",
+        handler: testHandlers[4],
+      });
+    });
+  });
+
+  describe("router", () => {
+    it("resolves /router", async () => {
+      expect(await app.resolve("/router")).toMatchObject({
+        route: "/router",
+        handler: testHandlers[5],
+      });
+      expect(await app.resolve("/router/")).toMatchObject(
+        (await app.resolve("/router")) as any,
+      );
+    });
+
+    it("resolves /router/:id", async () => {
+      expect(await app.resolve("/router/foo")).toMatchObject({
+        route: "/router/:id",
+        handler: testHandlers[6],
+      });
+    });
+  });
+});

--- a/test/status.test.ts
+++ b/test/status.test.ts
@@ -126,7 +126,7 @@ describe("setResponseStatus", () => {
         body: "",
       });
 
-      console.log(res.headers);
+      // console.log(res.headers);
 
       expect(res).toMatchObject({
         status: 304,


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR exposes a new `app.resolve(path)` method that can be used to resolve an even handler matching path (method unspecified/get for now).

This API is useful to access handlers for new APIs such as WebSocket or accessing handler meta.

Resolver is async to allow lazy methods.

App, Nested App, Lazy handlers and Router are supported and tested.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
