### PR TITLE
docs: fix spelling and grammar mistakes in Event Object

### DIFF
--- a/docs/1.guide/4.event.md
+++ b/docs/1.guide/4.event.md
@@ -6,7 +6,7 @@ icon: material-symbols-light:data-object
 
 > Event object carries an incoming request and context.
 
-Everytime a new HTTP requerst comes, h3 internally create an Event object and passes it though event handlers until sending response.
+Every time a new HTTP request comes, h3 internally creates an Event object and passes it though event handlers until sending the response.
 
 An event is passed through all the lifecycle hooks and composable utils to use it as context.
 
@@ -41,7 +41,7 @@ The main properties of an event are:
 
 ### `event.node`
 
-The `event.node` allows to access the native Node.js request and response. In runtimes other than Node.js/Bun, h3 makes a compatible shim using [unjs/unenv](https://unenv.unjs.io).
+The `event.node` allows you to access the native Node.js request and response. In runtimes other than Node.js/Bun, h3 makes a compatible shim using [unjs/unenv](https://unenv.unjs.io).
 
 > [!IMPORTANT]
 > Try to **avoid** depending on `event.node.*` context as much as you can and instead prefer h3 utils.
@@ -55,7 +55,7 @@ defineEventHandler((event) => {
 
 ### `event.web?`
 
-Only if available, it is an object with [`request`](https://developer.mozilla.org/en-US/docs/Web/API/Request/Request) and [`url`](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL) propertiers to access native web request context.
+If available, an object with [`request`](https://developer.mozilla.org/en-US/docs/Web/API/Request/Request) and [`url`](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL) properties to access native web request context.
 
 ### `event.method`
 
@@ -63,7 +63,7 @@ Access to the normalized (uppercase) request [method](https://developer.mozilla.
 
 ### `event.path`
 
-Access to the request request path. (**Example:** `/test?test=123`)
+Access to the request path. (**Example:** `/test?test=123`)
 
 - `context` with some context information about the request.
 - `headers` with a **normalized version** of the headers of the request.
@@ -71,7 +71,7 @@ Access to the request request path. (**Example:** `/test?test=123`)
 
 ### `event.headers`
 
-Access tp the normalized request [Headers](https://developer.mozilla.org/en-US/docs/Web/API/Headers).
+Access to the normalized request [Headers](https://developer.mozilla.org/en-US/docs/Web/API/Headers).
 
 > [!TIP]
 > You can alternatively use `getHeaders(event)` or `getHeader(event, name)` for a simplified interface.
@@ -83,13 +83,13 @@ You can store your custom properties inside `event.context` to share across comp
 
 ### `event.handled`
 
-Specifies if response is already handled or not. Initially for each request it is `false` and when a response is generated, it is set to `true`.
+Specifies if response is already handled or not. Initially for each request it is `false`, and when a response is generated, it is set to `true`.
 
 **Advanced:** If you manually handle the response, set it to `true` to tell h3 stop sending any responses.
 
 ## Methods
 
-Actually, h3 provide a function to help you to create a response before the end of the request.
+h3 provides a function to help you to create a response before the end of the request.
 
 ### `event.respondWith`
 
@@ -101,7 +101,7 @@ You must craft a response using the [`Response`](https://developer.mozilla.org/e
 > Prefer explicit `return` over `respondWith` as best practice.
 
 > [!IMPORTANT]
-> A `responseWith` will **always** take precedence over the returned value, from current and next event handlers. If there is no returned value, the request will continue until the end of the stack runner.
+> A `responseWith` call will **always** take precedence over the returned value, from current and next event handlers. If there is no returned value, the request will continue until the end of the stack runner.
 
 **Example:**
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Various spelling and grammar mistakes in the (Event Object)[https://h3.unjs.io/guide/event] documentation page.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
