### PR TITLE
feat(events): bodyValidator and queryValidator event arguments

### DIFF
--- a/src/event/utils.ts
+++ b/src/event/utils.ts
@@ -1,4 +1,3 @@
-import { getQuery, readBody } from "src/utils";
 import type {
   EventHandler,
   LazyEventHandler,
@@ -9,8 +8,10 @@ import type {
   _ResponseMiddleware,
 } from "../types";
 import { hasProp } from "../utils/internal/object";
+import { validateData } from "../utils/internal/validate";
+import { readBody } from "../utils/body";
+import { getQuery } from "../utils/request";
 import type { H3Event } from "./event";
-import { validateData } from "src/utils/internal/validate";
 
 type _EventHandlerHooks = {
   onRequest?: _RequestMiddleware[];

--- a/src/event/utils.ts
+++ b/src/event/utils.ts
@@ -71,11 +71,11 @@ export function defineEventHandler<
   const _handler: EventHandler<Request, any> = async (event) => {
     if (handler.bodyValidator) {
       const body = await readBody(event);
-      validateData(body, handler.bodyValidator);
+      await validateData(body, handler.bodyValidator);
     }
     if (handler.queryValidator) {
       const query = getQuery(event);
-      validateData(query, handler.queryValidator);
+      await validateData(query, handler.queryValidator);
     }
     return _callHandler(event, handler.handler, _hooks);
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@ import type { Hooks as WSHooks } from "crossws";
 import type { H3Event } from "./event";
 import type { Session } from "./utils/session";
 import type { RouteNode } from "./router";
+import type { ValidateFunction } from "./types";
 
 export type {
   ValidateFunction,
@@ -51,9 +52,12 @@ export interface H3EventContext extends Record<string, any> {
 
 export type EventHandlerResponse<T = any> = T | Promise<T>;
 
-export interface EventHandlerRequest {
-  body?: any; // TODO: Default to unknown in next major version
-  query?: QueryObject;
+export interface EventHandlerRequest<
+  Body = any, // TODO: Default to unknown in next major version
+  Query extends QueryObject | undefined = QueryObject | undefined,
+> {
+  body?: Body;
+  query?: Query;
   routerParams?: Record<string, string>;
 }
 
@@ -92,7 +96,12 @@ export type _ResponseMiddleware<
 ) => void | Promise<void>;
 
 export type EventHandlerObject<
-  Request extends EventHandlerRequest = EventHandlerRequest,
+  Body extends EventHandlerRequest["body"] = EventHandlerRequest["body"],
+  Query extends EventHandlerRequest["query"] = EventHandlerRequest["query"],
+  Request extends EventHandlerRequest<Body, Query> = EventHandlerRequest<
+    Body,
+    Query
+  >,
   Response extends EventHandlerResponse = EventHandlerResponse,
 > = {
   onRequest?: _RequestMiddleware<Request> | _RequestMiddleware<Request>[];
@@ -101,6 +110,8 @@ export type EventHandlerObject<
     | _ResponseMiddleware<Request, Response>[];
   /** @experimental */
   websocket?: Partial<WSHooks>;
+  bodyValidator?: ValidateFunction<Body>;
+  queryValidator?: ValidateFunction<Query>;
   handler: EventHandler<Request, Response>;
 };
 

--- a/src/utils/body.ts
+++ b/src/utils/body.ts
@@ -142,7 +142,7 @@ export function readRawBody<E extends Encoding = "utf8">(
 export async function readBody<
   T,
   Event extends H3Event = H3Event,
-  _T = InferEventInput<"body", Event, T>,
+  _T = Exclude<InferEventInput<"body", Event, T>, undefined>,
 >(event: Event, options: { strict?: boolean } = {}): Promise<_T> {
   const request = event.node.req as InternalRequest<T>;
   if (hasProp(request, ParsedBodySymbol)) {

--- a/test/types.test-d.ts
+++ b/test/types.test-d.ts
@@ -34,6 +34,7 @@ describe("types", () => {
         foo: string;
       }>();
     });
+
     it("return type (inferred)", () => {
       const handler = eventHandler(() => {
         return {
@@ -45,7 +46,7 @@ describe("types", () => {
     });
 
     it("return type (simple generic)", () => {
-      const handler = eventHandler<string>(() => {
+      const handler = eventHandler<undefined, undefined, {}, string>(() => {
         return "";
       });
       const response = handler({} as H3Event);
@@ -77,10 +78,19 @@ describe("types", () => {
         expectTypeOf(body).not.toBeAny();
         expectTypeOf(body).toEqualTypeOf<{ id: string }>();
       });
+
+      eventHandler({
+        bodyValidator: (body: unknown) => body as { id: string },
+        handler: async (event) => {
+          const body = await readBody(event);
+          expectTypeOf(body).not.toBeAny();
+          expectTypeOf(body).toEqualTypeOf<{ id: string }>();
+        }
+      });
     });
 
     it("typed via event handler", () => {
-      eventHandler<{ body: { id: string } }>(async (event) => {
+      eventHandler<{ id: string }>(async (event) => {
         const body = await readBody(event);
         expectTypeOf(body).not.toBeAny();
         expectTypeOf(body).toEqualTypeOf<{ id: string }>();
@@ -107,15 +117,24 @@ describe("types", () => {
 
     it("typed via validator", () => {
       eventHandler(async (event) => {
-        const validator = (body: unknown) => body as { id: string };
-        const body = await getValidatedQuery(event, validator);
-        expectTypeOf(body).not.toBeAny();
-        expectTypeOf(body).toEqualTypeOf<{ id: string }>();
+        const validator = (query: unknown) => query as { id: string };
+        const query = await getValidatedQuery(event, validator);
+        expectTypeOf(query).not.toBeAny();
+        expectTypeOf(query).toEqualTypeOf<{ id: string }>();
+      });
+
+      eventHandler({
+        queryValidator: (query: unknown) => query as { id: string },
+        handler: (event) => {
+          const query = getQuery(event);
+          expectTypeOf(query).not.toBeAny();
+          expectTypeOf(query).toEqualTypeOf<{ id: string }>();
+        }
       });
     });
 
     it("typed via event handler", () => {
-      eventHandler<{ query: { id: string } }>((event) => {
+      eventHandler<undefined, { id: string }>((event) => {
         const query = getQuery(event);
         expectTypeOf(query).not.toBeAny();
         expectTypeOf(query).toEqualTypeOf<{ id: string }>();


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

unjs/nitro#2244

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

These changes introduce `bodyValidator` and `queryValidator` options to `defineEventHandler`. These can be passed validation functions, such as a Zod schema's `parse` method, to validate request bodies and query parameters and type them in the handler.

```ts
export default defineEventHandler({
  bodyValidator: z.object({
    id: z.string()
  }).parse,
  handler: async (event) => {
    const { id } = await readBody(event);
    // id is inferred as a string now
  }
});
```

This will also allow Nitro to type the `body` and `query` options of `$fetch` since the required types of the body and query can now be inferred from the event handler, something like this...

```ts
type Body = typeof import('../../routes/foo').default extends EventHandler<infer Request> 
  ? Request['body'] 
  : any
```

...opening the door to...

```ts
await $fetch('/foo', {
  method: 'POST',
  body: {}, // <-- body inferred as { id: string } from the Zod Schema, so this is a TS error
});
```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
