### PR TITLE
docs(error-handling): add string vs object errors and update `createError` jsdoc

### DIFF
--- a/docs/1.guide/2.event-handler.md
+++ b/docs/1.guide/2.event-handler.md
@@ -98,11 +98,13 @@ You can easily control the error returned by using the `createError` utility.
 import { createError, defineEventHandler } from "h3";
 
 app.use(
-  "/hello",
+  "/validate",
   defineEventHandler((event) => {
     throw createError({
       status: 400,
-      message: "An error occurred",
+      statusMessage: "Bad Request",
+      message: "Invalid user input",
+      data: { field: "email" }
     });
   }),
 );
@@ -134,7 +136,7 @@ app.use(
 
 > [!TIP]
 > Typically, `message` contains a brief, human-readable description of the error, while `statusMessage` is specific to HTTP responses and describes the status text related to the response status code.
-> In a client-server context, using a short `statusMessage` is recommended because it can be accessed on the client side. Otherwise, a `message` passed to `createError` on the server will not propagate to the client. Consider avoiding to put dynamic user input to the message to avoid potential security issues.
+> In a client-server context, using a short `statusMessage` is recommended because it can be accessed on the client side. Otherwise, a `message` passed to `createError` on the server will not propagate to the client (you can use `data` instead). Consider avoiding to put dynamic user input to the message to avoid potential security issues.
 
 ### Internal errors
 

--- a/docs/1.guide/2.event-handler.md
+++ b/docs/1.guide/2.event-handler.md
@@ -134,7 +134,7 @@ app.use(
 
 > [!TIP]
 > Typically, `message` contains a brief, human-readable description of the error, while `statusMessage` is specific to HTTP responses and describes the status text related to the response status code.
-> In a client-server context, using `statusMessage` is recommended because it can be accessed on the client side. Otherwise, a `message` passed to `createError` on the server will not propagate to the client.
+> In a client-server context, using a short `statusMessage` is recommended because it can be accessed on the client side. Otherwise, a `message` passed to `createError` on the server will not propagate to the client. Consider avoiding to put dynamic user input to the message to avoid potential security issues.
 
 ### Internal errors
 

--- a/docs/1.guide/2.event-handler.md
+++ b/docs/1.guide/2.event-handler.md
@@ -117,6 +117,25 @@ This will end the request with `400 - Bad Request` status code and the following
 }
 ```
 
+### String vs. Object Errors
+
+When creating an error using `createError`, you also have the option to pass a string instead of an object. Doing so will set the `message` property of the error. In this case, the `statusCode` will default to `500`.
+
+```js
+import { createError, defineEventHandler } from "h3";
+
+app.use(
+  "/hello",
+  defineEventHandler((event) => {
+    throw createError("An error occurred");
+  }),
+);
+```
+
+> [!TIP]
+> Typically, `message` contains a brief, human-readable description of the error, while `statusMessage` is specific to HTTP responses and describes the status text related to the response status code.
+> In a client-server context, using `statusMessage` is recommended because it can be accessed on the client side. Otherwise, a `message` passed to `createError` on the server will not propagate to the client.
+
 ### Internal errors
 
 If during calling an event handler an error with `new Error()` will be thrown (without `createError`), h3 will automatically catch as a [`500 - Internal Server Error`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) status response considering it an unhandled error.

--- a/src/error.ts
+++ b/src/error.ts
@@ -65,10 +65,8 @@ export class H3Error<DataT = unknown> extends Error {
  * If a string is provided, it will be used as the error `message`.
  *
  * @example
- * ```js
  * // String error where `statusCode` defaults to `500`
  * throw createError("An error occurred");
- *
  * // Object error
  * throw createError({
  *   statusCode: 400,
@@ -76,14 +74,14 @@ export class H3Error<DataT = unknown> extends Error {
  *   message: "Invalid input",
  *   data: { field: "email" }
  * });
- * ```
+ *
  *
  * @return {H3Error} - An instance of H3Error.
  *
  * @remarks
- * - Typically, `message` contains a brief, human-readable description of the error, while `statusMessage` is specific to HTTP responses and describes 
+ * - Typically, `message` contains a brief, human-readable description of the error, while `statusMessage` is specific to HTTP responses and describes
  * the status text related to the response status code.
- * - In a client-server context, using a short `statusMessage` is recommended because it can be accessed on the client side. Otherwise, a `message` 
+ * - In a client-server context, using a short `statusMessage` is recommended because it can be accessed on the client side. Otherwise, a `message`
  * passed to `createError` on the server will not propagate to the client.
  * - Consider avoiding putting dynamic user input in the `message` to prevent potential security issues.
  */

--- a/src/error.ts
+++ b/src/error.ts
@@ -62,6 +62,7 @@ export class H3Error<DataT = unknown> extends Error {
  * Creates a new `Error` that can be used to handle both internal and runtime errors.
  *
  * @param input {string | (Partial<H3Error> & { status?: number; statusText?: string })} - The error message or an object containing error properties.
+ * If a string is provided, it will be used as the error `message`. Remember to use either `statusMessage` or `data` to pass error information to the client. 
  * @return {H3Error} - An instance of H3Error.
  */
 export function createError<DataT = unknown>(

--- a/src/error.ts
+++ b/src/error.ts
@@ -62,8 +62,30 @@ export class H3Error<DataT = unknown> extends Error {
  * Creates a new `Error` that can be used to handle both internal and runtime errors.
  *
  * @param input {string | (Partial<H3Error> & { status?: number; statusText?: string })} - The error message or an object containing error properties.
- * If a string is provided, it will be used as the error `message`. Remember to use either `statusMessage` or `data` to pass error information to the client. 
+ * If a string is provided, it will be used as the error `message`.
+ *
+ * @example
+ * ```js
+ * // String error where `statusCode` defaults to `500`
+ * throw createError("An error occurred");
+ *
+ * // Object error
+ * throw createError({
+ *   statusCode: 400,
+ *   statusMessage: "Bad Request",
+ *   message: "Invalid input",
+ *   data: { field: "email" }
+ * });
+ * ```
+ *
  * @return {H3Error} - An instance of H3Error.
+ *
+ * @remarks
+ * - Typically, `message` contains a brief, human-readable description of the error, while `statusMessage` is specific to HTTP responses and describes 
+ * the status text related to the response status code.
+ * - In a client-server context, using a short `statusMessage` is recommended because it can be accessed on the client side. Otherwise, a `message` 
+ * passed to `createError` on the server will not propagate to the client.
+ * - Consider avoiding putting dynamic user input in the `message` to prevent potential security issues.
  */
 export function createError<DataT = unknown>(
   input:


### PR DESCRIPTION
### 🔗 Linked issue

#761

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

I have always been somewhat confused on how to initialize `createError`, either with a string or an object. Similarly, it was unclear at first which one to use to pass data to the client in an error thrown from the server. 
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

### 🗒️ Note

This is my first-ever open source contribution so I may not have configured the issue/pr or the contribution itself as needed. I'd love to hear if that is the case and I'll fix whatever is missing.

And just for context: @pi0 this is the pr I am opening per your suggestion over Twitter. Thanks for the nudge!