### PR TITLE
docs: fix typo for `text/html` content-type

### DIFF
--- a/docs/1.guide/2.event-handler.md
+++ b/docs/1.guide/2.event-handler.md
@@ -52,7 +52,7 @@ defineEventHandler({
 Values returned from event handlers are automatically converted to responses. It can be:
 
 - JSON serializable value. If returning a JSON object or serializable value, it will be stringified and sent with default `application/json` content-type.
-- `string`: Sent as-is using default `application/html` content-type.
+- `string`: Sent as-is using default `text/html` content-type.
 - `null`: h3 with end response with `204 - No Content` status code.
 - [Web `ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream) or [node `Readable`](https://nodejs.org/api/stream.html#readable-streams)
 - [Web `ArrayBuffer`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer) or [node `Buffer`](https://nodejs.org/api/buffer.html#buffer)


### PR DESCRIPTION
I believe `text/html` is the correct content-type