### PR TITLE
docs: provide `async` for request body

### DIFF
--- a/docs/1.guide/4.event.md
+++ b/docs/1.guide/4.event.md
@@ -15,7 +15,7 @@ An event is passed through all the lifecycle hooks and composable utils to use i
 ```js
 import { defineEventHandler, getQuery, readBody } from "h3";
 
-app.use(defineEventHandler((event) => {
+app.use(defineEventHandler(async (event) => {
   // Log event. `.toString()` stringifies to a simple string like `[GET] /<path>`
   console.log(`Request: ${event.toString()}`);
 
@@ -106,13 +106,13 @@ You must craft a response using the [`Response`](https://developer.mozilla.org/e
 **Example:**
 
 ```js
-defineEventHandler(async(event) => {
+defineEventHandler(async (event) => {
   await event.respondWith(new Response("Hello World"));
   return "..."; // DOES NOT WORKS
 });
 
 app.use(
-  defineEventHandler(async(event) => {
+  defineEventHandler(async (event) => {
     await event.respondWith(new Response("Hello World"));
     return "..."; // DOES NOT WORK
   }),


### PR DESCRIPTION
**Reference:** #
There is `await readBody` inside `defineEventHandler`. It needs an async function. 
<!--
IMPORTANT IMPORTANT IMPORTANT IMPORTANT

- Discuss the issue/idea with the maintainers using an issue BEFORE.
- Please keep your changes minimal and split them if you need to.
- Ensure there is a minimal reproduction attached for bug fixes.
- PR titles should follow conventional commit guidelines. Examples:
  - fix(scope): resolve xyz
  - feat: add a new feature
  - docs: improve wording

This will greatly help speed up the review process.

Thanks for your contribution ❤️

IMPORTANT IMPORTANT IMPORTANT IMPORTANT
-->
