### PR TITLE
fix(plain): avoid import from unenv internals

### DIFF
--- a/src/adapters/plain.ts
+++ b/src/adapters/plain.ts
@@ -1,6 +1,8 @@
 import { IncomingMessage } from "node:http";
-import { IncomingMessage as NodeIncomingMessage } from "unenv/runtime/node/http/_request";
-import { ServerResponse as NodeServerResponse } from "unenv/runtime/node/http/_response";
+import {
+  IncomingMessage as NodeIncomingMessage,
+  ServerResponse as NodeServerResponse,
+} from "unenv/runtime/node/http";
 import type { App } from "../app";
 import type { HTTPMethod } from "../types";
 import { createError, isError, sendError } from "../error";


### PR DESCRIPTION
Found from https://github.com/unjs/unenv/issues/274#issuecomment-2178545076 /cc @farnabaz 

For plain handler we were importing from unenv internals which are not same in upcoming unenv v2.