### PR TITLE
feat!: `callWithWebRequest` and `callWithPlainRequest` utils

### DIFF
--- a/src/adapters/node/index.ts
+++ b/src/adapters/node/index.ts
@@ -4,7 +4,6 @@ export {
   // Handler
   fromNodeHandler,
   toNodeHandler,
-  callNodeHandler,
 
   // Request
   fromNodeRequest,

--- a/src/adapters/node/utils.ts
+++ b/src/adapters/node/utils.ts
@@ -11,11 +11,12 @@ import type {
   NodeServerResponse,
 } from "../../types/node";
 import { _kRaw } from "../../event";
-import { createError, isError, sendError } from "../../error";
+import { createError, errorToResponse, isError } from "../../error";
 import { defineEventHandler, isEventHandler } from "../../handler";
-import { setResponseStatus } from "../../utils/response";
+import { setResponseHeaders, setResponseStatus } from "../../utils/response";
 import { EventWrapper } from "../../event";
 import { NodeEvent } from "./event";
+import { callNodeHandler } from "./_internal";
 
 /**
  * Convert H3 app instance to a NodeHandler with (IncomingMessage, ServerResponse) => void signature.
@@ -38,17 +39,24 @@ export function toNodeHandler(app: App): NodeHandler {
       if (app.options.onError) {
         await app.options.onError(error, event);
       }
-      if (event[_kRaw].handled) {
-        return;
-      }
+
       if (error.unhandled || error.fatal) {
         console.error("[h3]", error.fatal ? "[fatal]" : "[unhandled]", error);
+      }
+
+      if (event[_kRaw].handled) {
+        return;
       }
 
       if (app.options.onBeforeResponse && !event._onBeforeResponseCalled) {
         await app.options.onBeforeResponse(event, { body: error });
       }
-      await sendError(event, error, !!app.options.debug);
+
+      const response = errorToResponse(error, app.options.debug);
+      setResponseStatus(event, response.status, response.statusText);
+      setResponseHeaders(event, response.headers);
+      await event[_kRaw].sendResponse(response.body);
+
       if (app.options.onAfterResponse && !event._onAfterResponseCalled) {
         await app.options.onAfterResponse(event, { body: error });
       }
@@ -98,34 +106,6 @@ export function fromNodeRequest(
   const rawEvent = new NodeEvent(req, res);
   const event = new EventWrapper(rawEvent);
   return event;
-}
-
-export function callNodeHandler(
-  handler: NodeHandler | NodeMiddleware,
-  req: NodeIncomingMessage,
-  res: NodeServerResponse,
-) {
-  const isMiddleware = handler.length > 2;
-  return new Promise((resolve, reject) => {
-    const next = (err?: Error) => {
-      if (isMiddleware) {
-        res.off("close", next);
-        res.off("error", next);
-      }
-      return err ? reject(createError(err)) : resolve(undefined);
-    };
-    try {
-      const returned = handler(req, res, next);
-      if (isMiddleware && returned === undefined) {
-        res.once("close", next);
-        res.once("error", next);
-      } else {
-        resolve(returned);
-      }
-    } catch (error) {
-      next(error as Error);
-    }
-  });
 }
 
 export function getNodeContext(

--- a/src/adapters/web/index.ts
+++ b/src/adapters/web/index.ts
@@ -12,6 +12,9 @@ export {
   // Web Context
   getWebContext,
 
+  // Call
+  callWithWebRequest,
+
   // --Plain--
 
   // Plain Handler
@@ -20,4 +23,7 @@ export {
 
   // Plain Request
   fromPlainRequest,
+
+  // Call
+  callWithPlainRequest,
 } from "./utils";

--- a/src/deprecated.ts
+++ b/src/deprecated.ts
@@ -19,7 +19,6 @@ import {
   setResponseHeaders,
 } from "./utils/response";
 import {
-  callNodeHandler,
   defineNodeHandler,
   fromNodeHandler,
   fromNodeRequest,
@@ -75,9 +74,6 @@ export const createEvent = fromNodeRequest;
 
 /** @deprecated Please use `toNodeHandler` */
 export const toNodeListener = toNodeHandler;
-
-/** @deprecated Please use `callNodeHandler` */
-export const callNodeListener = callNodeHandler;
 
 /** @deprecated Please use `readJSONBody` */
 export const readBody = readJSONBody;

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ export {
 } from "./handler";
 
 // Error
-export { createError, isError, sendError } from "./error";
+export { createError, isError } from "./error";
 
 // Router
 export { createRouter } from "./router";
@@ -34,7 +34,6 @@ export {
   fromNodeRequest,
   defineNodeHandler,
   defineNodeMiddleware,
-  callNodeHandler,
 } from "./adapters/node";
 
 // Web
@@ -47,6 +46,7 @@ export {
   fromPlainHandler,
   toPlainHandler,
   fromPlainRequest,
+  callWithWebRequest,
 } from "./adapters/web";
 
 // ------ Utils ------

--- a/src/types/web.ts
+++ b/src/types/web.ts
@@ -19,7 +19,7 @@ export interface PlainRequest {
 
 export interface PlainResponse {
   status: number;
-  statusText: string;
+  statusText: string | undefined;
   headers: Record<string, string>;
   setCookie: string[];
   body?: unknown;


### PR DESCRIPTION
Related to #787

This PR introduces two new `callWithWebRequest(handler, request)` and `callWithPlainRequest(handler, request)` utils to allow directly emulating a web request on an app or event handler instance.

As part of reactors, `sendError` and `callNodeHandler/`callNodeListener` were removed.