### PR TITLE
perf: improve response handling

### DIFF
--- a/src/adapters/node/internal/response.ts
+++ b/src/adapters/node/internal/response.ts
@@ -1,12 +1,10 @@
 import type { ServerResponse } from "node:http";
-import type { H3Event } from "../../../types";
+import type { H3EventResponse } from "../../../types/event";
 import { kNodeInspect, kNodeRes } from "./utils";
 import { NodeResHeadersProxy } from "./headers";
 
-type H3Response = H3Event["response"];
-
 export const NodeResponseProxy = /* @__PURE__ */ (() =>
-  class NodeResponseProxy implements H3Response {
+  class NodeResponseProxy implements H3EventResponse {
     [kNodeRes]: ServerResponse;
 
     headers: Headers;
@@ -34,6 +32,10 @@ export const NodeResponseProxy = /* @__PURE__ */ (() =>
 
     get [Symbol.toStringTag]() {
       return "Response";
+    }
+
+    setHeader(name: string, value: string): void {
+      this[kNodeRes].setHeader(name, value);
     }
 
     [kNodeInspect]() {

--- a/src/adapters/web/event.ts
+++ b/src/adapters/web/event.ts
@@ -16,7 +16,7 @@ export class WebEvent extends BaseEvent implements H3Event {
 }
 
 class WebEventResponse implements H3EventResponse {
-  _headersInit: [string, string][] = [];
+  _headersInit: Record<string, string> = Object.create(null);
   _headers?: Headers;
 
   get headers() {
@@ -30,7 +30,7 @@ class WebEventResponse implements H3EventResponse {
     if (this._headers) {
       this._headers.set(name, value);
     } else {
-      this._headersInit.push([name, value]);
+      this._headersInit[name] = value;
     }
   }
 }

--- a/src/adapters/web/event.ts
+++ b/src/adapters/web/event.ts
@@ -1,17 +1,36 @@
 import type { H3Event, H3EventContext } from "../../types";
+import type { H3EventResponse } from "../../types/event";
 import { BaseEvent } from "../base/event";
 
 export class WebEvent extends BaseEvent implements H3Event {
   request: Request;
   url: URL;
-  response: H3Event["response"];
+  response: H3EventResponse;
 
   constructor(request: Request, context?: H3EventContext) {
     super(context);
     this.request = request;
     this.url = new URL(request.url);
-    this.response = {
-      headers: new Headers(),
-    };
+    this.response = new WebEventResponse();
+  }
+}
+
+class WebEventResponse implements H3EventResponse {
+  _headersInit: [string, string][] = [];
+  _headers?: Headers;
+
+  get headers() {
+    if (!this._headers) {
+      this._headers = new Headers(this._headersInit);
+    }
+    return this._headers;
+  }
+
+  setHeader(name: string, value: string): void {
+    if (this._headers) {
+      this._headers.set(name, value);
+    } else {
+      this._headersInit.push([name, value]);
+    }
   }
 }

--- a/src/types/event.ts
+++ b/src/types/event.ts
@@ -22,5 +22,17 @@ export interface H3Event<
   readonly ip?: string | undefined;
 
   // Response
-  response: { headers: Headers; status?: number; statusText?: string };
+  response: H3EventResponse;
+}
+
+export interface H3EventResponse {
+  status?: number;
+  statusText?: string;
+
+  _headersInit?: HeadersInit;
+  _headers?: Headers;
+
+  readonly headers: Headers;
+
+  setHeader(name: string, value: string): void;
 }

--- a/src/types/h3.ts
+++ b/src/types/h3.ts
@@ -7,18 +7,9 @@ import type {
 } from "./handler";
 import type { H3Error } from "../error";
 import type { HTTPMethod } from "./http";
-import { H3EventContext } from "./context";
+import type { H3EventContext } from "./context";
 
 export type { H3Error } from "../error";
-
-export interface H3Response {
-  error?: H3Error;
-  body?: BodyInit | null;
-  contentType?: string;
-  headers?: Headers;
-  status?: number;
-  statusText?: string;
-}
 
 export interface H3Config {
   debug?: boolean;
@@ -28,12 +19,19 @@ export interface H3Config {
   onRequest?: (event: H3Event) => MaybePromise<void>;
   onBeforeResponse?: (
     event: H3Event,
-    response: H3Response,
+    response: PreparedResponse,
   ) => MaybePromise<void>;
   onAfterResponse?: (
     event: H3Event,
-    response?: H3Response,
+    response?: PreparedResponse,
   ) => MaybePromise<void>;
+}
+
+export interface PreparedResponse {
+  status?: number;
+  statusText?: string;
+  headers?: HeadersInit;
+  body?: BodyInit | null;
 }
 
 export interface WebSocketOptions {

--- a/src/utils/internal/consts.ts
+++ b/src/utils/internal/consts.ts
@@ -1,5 +1,0 @@
-export const MIMES = {
-  html: "text/html",
-  json: "application/json",
-  octetStream: "application/octet-stream",
-} as const;

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -166,17 +166,16 @@ describe("app", () => {
     expect(JSON.parse(res.text).statusMessage).toBe("test");
   });
 
-  it("can return HTML directly", async () => {
-    ctx.app.use(() => "<h1>Hello world!</h1>");
+  it("can return text directly", async () => {
+    ctx.app.use(() => "Hello world!");
     const res = await ctx.request.get("/");
 
-    expect(res.text).toBe("<h1>Hello world!</h1>");
-    expect(res.header["content-type"]).toBe("text/html");
+    expect(res.text).toBe("Hello world!");
   });
 
   it("allows overriding Content-Type", async () => {
     ctx.app.use((event) => {
-      setResponseHeader(event, "content-type", "text/xhtml");
+      event.response.setHeader("content-type", "text/xhtml");
       return "<h1>Hello world!</h1>";
     });
     const res = await ctx.request.get("/");

--- a/test/bench/impl.ts
+++ b/test/bench/impl.ts
@@ -17,7 +17,7 @@ export function h3(lib: typeof _h3src) {
 
   // [GET] /id/:id
   app.get("/id/:id", (event) => {
-    event.response.headers.set("x-powered-by", "benchmark");
+    event.response.setHeader("x-powered-by", "benchmark");
     return `${event.context.params!.id} ${event.url.searchParams.get("name")}`;
   });
 

--- a/test/hooks.test.ts
+++ b/test/hooks.test.ts
@@ -40,9 +40,9 @@ describe("app", () => {
     expect(ctx.onAfterResponse).toHaveBeenCalledTimes(1);
   });
 
-  it("calls onRequest and onResponse when an error is returned", async () => {
+  it("calls onRequest and onResponse when an error is thrown", async () => {
     ctx.app.use(() => {
-      return createError({
+      throw createError({
         statusCode: 404,
       });
     });
@@ -68,9 +68,11 @@ describe("app", () => {
     vi.spyOn(console, "error").mockImplementation(() => {});
     await ctx.request.get("/foo");
 
-    expect(ctx.errors.length).toBe(1);
-    expect(ctx.errors[0].statusCode).toBe(500);
+    const errors = ctx.errors;
     ctx.errors = [];
+
+    expect(errors.length).toBe(1);
+    expect(errors[0].statusCode).toBe(500);
 
     expect(ctx.onRequest).toHaveBeenCalledTimes(1);
     expect(ctx.onRequest.mock.calls[0][0].path).toBe("/foo");

--- a/test/proxy.test.ts
+++ b/test/proxy.test.ts
@@ -452,7 +452,9 @@ describe("proxy", () => {
 
       await ctx.request.get("/");
 
-      expect(headers?.["content-type"]).toEqual("application/json");
+      expect(headers?.["content-type"]).toEqual(
+        "application/json; charset=utf-8",
+      );
     });
   });
 });

--- a/test/status.test.ts
+++ b/test/status.test.ts
@@ -27,13 +27,14 @@ describe("setResponseStatus", () => {
         statusText: "",
         body: "text",
         headers: {
-          "content-type": "text/html",
+          "content-type": "text/plain;charset=UTF-8",
         },
       });
     });
-    it("override status and statusText with setResponseStatus method", async () => {
+    it("override status and statusText", async () => {
       ctx.app.use("/test", (event) => {
-        setResponseStatus(event, 418, "status-text");
+        event.response.status = 418;
+        event.response.statusText = "status-text";
         return "text";
       });
 
@@ -47,7 +48,7 @@ describe("setResponseStatus", () => {
         statusText: "status-text",
         body: "text",
         headers: {
-          "content-type": "text/html",
+          "content-type": "text/plain;charset=UTF-8",
         },
       });
     });

--- a/test/web.test.ts
+++ b/test/web.test.ts
@@ -34,7 +34,7 @@ describe("Web handler", () => {
     expect(res.status).toBe(201);
     expect(res.statusText).toBe("Created");
     expect([...res.headers.entries()]).toMatchObject([
-      ["content-type", "application/json"],
+      ["content-type", "application/json; charset=utf-8"],
     ]);
 
     expect(await res.json()).toMatchObject({


### PR DESCRIPTION
This PR improves raw web perf by ~10% by avoiding creating a `Headers` object in default/fast paths (finally `new Response()` does create one)

A new `event.response.setHeader` utility is introduced to allow setting headers on headers-init object via fast path (if `event.response.headers` is accessed, we fallback to full headers functionality)

This PR additionally makes behavior changes:
- `onError` is only called when error is throwing with `throw`. `return <error>` is normal response
- Returning a static string, does not sets HTML content type
- Default content type is `application/json; charset=utf-8` (normalized value of headers)