### PR TITLE
build: reduce dependencies

### DIFF
--- a/build.config.ts
+++ b/build.config.ts
@@ -3,6 +3,7 @@ import { defineBuildConfig } from "unbuild";
 export default defineBuildConfig({
   declaration: true,
   rollup: {
+    inlineDependencies: true,
     esbuild: {
       target: "ES2022",
       tsconfigRaw: {

--- a/build.config.ts
+++ b/build.config.ts
@@ -3,7 +3,7 @@ import { defineBuildConfig } from "unbuild";
 export default defineBuildConfig({
   declaration: true,
   rollup: {
-    inlineDependencies: true,
+    // inlineDependencies: true,
     esbuild: {
       target: "ES2022",
       tsconfigRaw: {

--- a/package.json
+++ b/package.json
@@ -41,10 +41,7 @@
   },
   "dependencies": {
     "cookie-es": "^1.2.1",
-    "iron-webcrypto": "^1.2.1",
-    "ohash": "^1.1.3",
-    "rou3": "^0.4.0",
-    "uncrypto": "^0.1.3"
+    "rou3": "^0.4.0"
   },
   "devDependencies": {
     "@types/connect": "^3.4.38",
@@ -66,9 +63,11 @@
     "get-port-please": "^3.1.2",
     "h3-nightly": "npm:h3-nightly@2.0.0-1720699896.4a34c89",
     "h3-v1": "npm:h3@^1.12.0",
+    "iron-webcrypto": "^1.2.1",
     "jiti": "2.0.0-beta.3",
     "listhen": "^1.7.2",
     "mitata": "^0.1.11",
+    "ohash": "^1.1.3",
     "prettier": "^3.3.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   },
   "dependencies": {
     "cookie-es": "^1.2.1",
+    "iron-webcrypto": "^1.2.1",
     "rou3": "^0.4.0"
   },
   "devDependencies": {
@@ -63,7 +64,6 @@
     "get-port-please": "^3.1.2",
     "h3-nightly": "npm:h3-nightly@2.0.0-1720699896.4a34c89",
     "h3-v1": "npm:h3@^1.12.0",
-    "iron-webcrypto": "^1.2.1",
     "jiti": "2.0.0-beta.3",
     "listhen": "^1.7.2",
     "mitata": "^0.1.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,18 +14,9 @@ importers:
       crossws:
         specifier: ^0.2.4
         version: 0.2.4
-      iron-webcrypto:
-        specifier: ^1.2.1
-        version: 1.2.1
-      ohash:
-        specifier: ^1.1.3
-        version: 1.1.3
       rou3:
         specifier: ^0.4.0
         version: 0.4.0
-      uncrypto:
-        specifier: ^0.1.3
-        version: 0.1.3
     devDependencies:
       '@types/connect':
         specifier: ^3.4.38
@@ -84,6 +75,9 @@ importers:
       h3-v1:
         specifier: npm:h3@^1.12.0
         version: h3@1.12.0
+      iron-webcrypto:
+        specifier: ^1.2.1
+        version: 1.2.1
       jiti:
         specifier: 2.0.0-beta.3
         version: 2.0.0-beta.3
@@ -93,6 +87,9 @@ importers:
       mitata:
         specifier: ^0.1.11
         version: 0.1.11
+      ohash:
+        specifier: ^1.1.3
+        version: 1.1.3
       prettier:
         specifier: ^3.3.3
         version: 3.3.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       crossws:
         specifier: ^0.2.4
         version: 0.2.4
+      iron-webcrypto:
+        specifier: ^1.2.1
+        version: 1.2.1
       rou3:
         specifier: ^0.4.0
         version: 0.4.0
@@ -75,9 +78,6 @@ importers:
       h3-v1:
         specifier: npm:h3@^1.12.0
         version: h3@1.12.0
-      iron-webcrypto:
-        specifier: ^1.2.1
-        version: 1.2.1
       jiti:
         specifier: 2.0.0-beta.3
         version: 2.0.0-beta.3

--- a/src/types/utils/session.ts
+++ b/src/types/utils/session.ts
@@ -1,5 +1,4 @@
 import type { CookieSerializeOptions } from "cookie-es";
-import type { SealOptions } from "iron-webcrypto";
 import type { kGetSession } from "../../utils/internal/session";
 
 type SessionDataT = Record<string, any>;
@@ -28,4 +27,64 @@ export interface SessionConfig {
   crypto?: Crypto;
   /** Default is Crypto.randomUUID */
   generateId?: () => string;
+}
+
+// -- From iron-webcrypto ---
+
+/**
+ * Algorithm used for encryption and decryption.
+ */
+type EncryptionAlgorithm = "aes-128-ctr" | "aes-256-cbc";
+/**
+ * Algorithm used for integrity verification.
+ */
+type IntegrityAlgorithm = "sha256";
+/**
+ * @internal
+ */
+type _Algorithm = EncryptionAlgorithm | IntegrityAlgorithm;
+
+/**
+ * Options for customizing the key derivation algorithm used to generate encryption and integrity verification keys as well as the algorithms and salt sizes used.
+ */
+interface SealOptions {
+  /**
+   * Encryption step options.
+   */
+  encryption: SealOptionsSub<EncryptionAlgorithm>;
+  /**
+   * Integrity step options.
+   */
+  integrity: SealOptionsSub<IntegrityAlgorithm>;
+  /**
+   * Sealed object lifetime in milliseconds where 0 means forever. Defaults to 0.
+   */
+  ttl: number;
+  /**
+   * Number of seconds of permitted clock skew for incoming expirations. Defaults to 60 seconds.
+   */
+  timestampSkewSec: number;
+  /**
+   * Local clock time offset, expressed in number of milliseconds (positive or negative). Defaults to 0.
+   */
+  localtimeOffsetMsec: number;
+}
+
+interface SealOptionsSub<Algorithm extends _Algorithm = _Algorithm> {
+  /**
+   * The length of the salt (random buffer used to ensure that two identical objects will generate a different encrypted result). Defaults to 256.
+   */
+  saltBits: number;
+  /**
+   * The algorithm used. Defaults to 'aes-256-cbc' for encryption and 'sha256' for integrity.
+   */
+  algorithm: Algorithm;
+  /**
+   * The number of iterations used to derive a key from the password. Defaults to 1.
+   */
+  iterations: number;
+  /**
+   * Minimum password size. Defaults to 32.
+   */
+  minPasswordlength: number;
 }

--- a/src/utils/fingerprint.ts
+++ b/src/utils/fingerprint.ts
@@ -1,5 +1,4 @@
 import type { H3Event, RequestFingerprintOptions } from "../types";
-import crypto from "uncrypto";
 import { getRequestIP } from "./request";
 
 /**
@@ -42,7 +41,7 @@ export async function getRequestFingerprint(
     return fingerprintString;
   }
 
-  const buffer = await crypto.subtle.digest(
+  const buffer = await globalThis.crypto.subtle.digest(
     opts.hash || "SHA-1",
     new TextEncoder().encode(fingerprintString),
   );

--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -1,5 +1,4 @@
 import type { H3Event, Session, SessionConfig, SessionData } from "../types";
-import crypto from "uncrypto";
 import { seal, unseal, defaults as sealDefaults } from "iron-webcrypto";
 import { getCookie, setCookie } from "./cookie";
 import {
@@ -98,7 +97,8 @@ export async function getSession<T extends SessionData = SessionData>(
   // New session store in response cookies
   if (!session.id) {
     session.id =
-      config.generateId?.() ?? (config.crypto || crypto).randomUUID();
+      config.generateId?.() ??
+      (config.crypto || globalThis.crypto).randomUUID();
     session.createdAt = Date.now();
     await updateSession(event, config);
   }


### PR DESCRIPTION
- removed ohash dependency (unused)
- ~~removed uncrypto dependency (depend on native `globalThis.crypto`)~~ `uncrypto` is needed for Node 18 (we might need a subpath to fix)
- ~~removed `iron-webcrypto`~~ `iron-webcrypto` cannot be bundled because it adds a little bit of a side-effect. (need to investigate later)

`cookie-es` and `rou3` are still deps as might be shared (might remove them in later PR to make h3 zero dep - if can reuse them)