### PR TITLE
docs: add detailed error response example

### DIFF
--- a/docs/1.guide/2.event-handler.md
+++ b/docs/1.guide/2.event-handler.md
@@ -105,8 +105,12 @@ This will end the request with `400 - Bad Request` status code and the following
 
 ```json
 {
-  "status": 400,
-  "message": "An error occurred"
+  "statusCode": 400,
+  "statusMessage": "Bad Request",
+  "stack": [],
+  "data": {
+    "field": "email"
+  }
 }
 ```
 


### PR DESCRIPTION
Some properties are missing in the return json from docs.

The correct response for the first example of [Error Handling](https://h3.unjs.io/guide/event-handler#error-handling) is:

```json
{
  "statusCode": 400,
  "statusMessage": "Bad Request",
  "stack": [],
  "data": {
    "field": "email"
  }
}
```

Reference: Response in Hoppscotch:
<img width="970" alt="image" src="https://github.com/user-attachments/assets/7d0a9c98-d33f-4ce7-ac0f-02955ceed0b0">


<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->
