### PR TITLE
perf: reduce the cost of global middleware

### DIFF
--- a/test/bench/bench.test.ts
+++ b/test/bench/bench.test.ts
@@ -15,7 +15,6 @@ describe("benchmark", async () => {
               body: request.body,
             }),
           );
-          expect(response.status).toBe(200);
           if (request.response.body) {
             expect(await response.text()).toBe(request.response.body);
           }
@@ -26,6 +25,7 @@ describe("benchmark", async () => {
               expect(response.headers.get(key)).toBe(value);
             }
           }
+          expect(response.status).toBe(200);
         });
       }
     }

--- a/test/bench/impl.ts
+++ b/test/bench/impl.ts
@@ -1,9 +1,15 @@
 import * as _h3src from "../../src";
 import * as _h3v1 from "h3-v1";
+import * as _h3nightly from "h3-nightly";
 
 export function createInstances() {
   return [
     ["h3", h3(_h3src)],
+    ["h3-middleware", h3Middleware(_h3src)],
+    [
+      "h3-middleware-nightly",
+      h3Middleware(_h3nightly as unknown as typeof _h3src),
+    ],
     // ["h3-v1", h3v1()],
     ["maximum", fastest()],
   ] as const;
@@ -23,6 +29,28 @@ export function h3(lib: typeof _h3src) {
 
   // [POST] /json
   app.post("/json", (event) => event.request.json());
+
+  return app.fetch;
+}
+
+export function h3Middleware(lib: typeof _h3src) {
+  const app = lib.createH3();
+
+  // Global middleware
+  app.use(() => {});
+  app.use(() => Promise.resolve());
+
+  // [GET] /
+  app.use("/", () => "Hi");
+
+  // [GET] /id/:id
+  app.use("/id/:id", (event) => {
+    event.response.setHeader("x-powered-by", "benchmark");
+    return `${event.context.params!.id} ${event.url.searchParams.get("name")}`;
+  });
+
+  // [POST] /json
+  app.use("/json", (event) => event.request.json());
 
   return app.fetch;
 }

--- a/test/bench/impl.ts
+++ b/test/bench/impl.ts
@@ -5,11 +5,7 @@ import * as _h3nightly from "h3-nightly";
 export function createInstances() {
   return [
     ["h3", h3(_h3src)],
-    ["h3-middleware", h3Middleware(_h3src)],
-    [
-      "h3-middleware-nightly",
-      h3Middleware(_h3nightly as unknown as typeof _h3src),
-    ],
+    // ["h3-middleware", h3Middleware(_h3src)],
     // ["h3-v1", h3v1()],
     ["maximum", fastest()],
   ] as const;

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -235,9 +235,9 @@ describe("event.context.matchedRoute", () => {
   });
 
   describe("without router", () => {
-    it("can return `undefined` for matched path", async () => {
+    it("middleware can access matched route", async () => {
       ctx.app.use("/**", (event) => {
-        expect(event.context.matchedRoute).toEqual(undefined);
+        expect(event.context.matchedRoute).toMatchObject({ route: "/**" });
         return "200";
       });
       const result = await ctx.request.get("/test/path");

--- a/test/web.test.ts
+++ b/test/web.test.ts
@@ -48,7 +48,7 @@ describe("Web handler", () => {
       query: {
         test: "123",
       },
-      contextKeys: ["test"],
+      contextKeys: ["test", "params", "matchedRoute"],
     });
   });
 });


### PR DESCRIPTION
Running global and scoped middleware has a cost. This PR slightly reduces the cost by using promise chains.

Additional fixes:
- router context is now available for routed middleware
- global middleware match method if specified


