### PR TITLE
perf: fast path for pathname for routing

### DIFF
--- a/src/adapters/node/event.ts
+++ b/src/adapters/node/event.ts
@@ -30,6 +30,10 @@ export const NodeEvent = /* @__PURE__ */ (() =>
       return this.node.req.url || "/";
     }
 
+    get pathname(): string {
+      return this.url.pathname;
+    }
+
     get method(): HTTPMethod {
       return this.node.req.method as HTTPMethod;
     }

--- a/src/adapters/web/event.ts
+++ b/src/adapters/web/event.ts
@@ -4,14 +4,38 @@ import { BaseEvent } from "../base/event";
 
 export class WebEvent extends BaseEvent implements H3Event {
   request: Request;
-  url: URL;
   response: H3EventResponse;
+
+  _url?: URL;
 
   constructor(request: Request, context?: H3EventContext) {
     super(context);
     this.request = request;
-    this.url = new URL(request.url);
     this.response = new WebEventResponse();
+  }
+
+  get url() {
+    if (!this._url) {
+      this._url = new URL(this.request.url);
+    }
+    return this._url;
+  }
+
+  get pathname() {
+    if (this._url) {
+      return this._url.pathname; // reuse parsed URL
+    }
+    const url = this.request.url;
+    const protoIndex = url.indexOf("://");
+    if (protoIndex === -1) {
+      return this.url.pathname; // deoptimize
+    }
+    const pIndex = url.indexOf("/", protoIndex + 4 /* ://* */);
+    if (pIndex === -1) {
+      return this.url.pathname; // deoptimize
+    }
+    const qIndex = url.indexOf("?", pIndex);
+    return url.slice(pIndex, qIndex === -1 ? undefined : qIndex);
   }
 }
 

--- a/src/types/event.ts
+++ b/src/types/event.ts
@@ -16,6 +16,7 @@ export interface H3Event<
   // Request
   readonly method: HTTPMethod;
   readonly path: string;
+  readonly pathname: string;
   readonly url: URL;
   readonly headers: Headers;
   readonly request: Request;

--- a/test/bench/bundle.test.ts
+++ b/test/bench/bundle.test.ts
@@ -11,8 +11,8 @@ describe("benchmark", () => {
       export default createH3();
     `;
     const { bytes, gzipSize } = await getBundleSize(code);
-    // console.log(`Bundle size: ${bytes} (gzip: ${gzipSize})`);
-    expect(bytes).toBeLessThanOrEqual(10_000); // <10kb
+    console.log(`Bundle size: ${bytes} (gzip: ${gzipSize})`);
+    expect(bytes).toBeLessThanOrEqual(11_000); // <11kb
     expect(gzipSize).toBeLessThanOrEqual(4000); // <4kb
   });
 });

--- a/test/bench/impl.ts
+++ b/test/bench/impl.ts
@@ -5,9 +5,10 @@ import * as _h3nightly from "h3-nightly";
 export function createInstances() {
   return [
     ["h3", h3(_h3src)],
+    ["h3-nightly", h3(_h3nightly as any)],
     // ["h3-middleware", h3Middleware(_h3src)],
     // ["h3-v1", h3v1()],
-    ["maximum", fastest()],
+    ["std", std()],
   ] as const;
 }
 
@@ -81,7 +82,7 @@ export function h3v1() {
   return _h3v1.toWebHandler(app);
 }
 
-export function fastest() {
+export function std() {
   return function (req: Request): Response | Promise<Response> {
     const url = new URL(req.url);
     switch (req.method) {

--- a/test/bench/impl.ts
+++ b/test/bench/impl.ts
@@ -5,7 +5,7 @@ import * as _h3nightly from "h3-nightly";
 export function createInstances() {
   return [
     ["h3", h3(_h3src)],
-    ["h3-nightly", h3(_h3nightly as any)],
+    // ["h3-nightly", h3(_h3nightly as any)],
     // ["h3-middleware", h3Middleware(_h3src)],
     // ["h3-v1", h3v1()],
     ["std", std()],


### PR DESCRIPTION
Creating a `URL` instance of `request.url` with full parsing (even though it is native!) has a cost.

This PR improves web performance by ~%10 on bun by introducing new `event.pathname` that in web APIs, if URL is not already parsed uses a faster method to extract pathname (used in critical path of event handling for matching routes)