### PR TITLE
perf(web): fast path for returning `Response`

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "express": "^4.19.2",
     "get-port": "^7.1.0",
     "get-port-please": "^3.1.2",
-    "h3-nightly": "npm:h3-nightly@2.0.0-1721833939.ba90fcd",
+    "h3-nightly": "npm:h3-nightly@2.0.0-1721834829.5ca45e1",
     "h3-v1": "npm:h3@^1.12.0",
     "jiti": "2.0.0-beta.3",
     "listhen": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   ],
   "scripts": {
     "bench:bun": "bun run ./test/bench",
-    "bench:node": "node --import jiti/loader ./test/bench",
+    "bench:node": "node --import jiti/register ./test/bench",
     "build": "unbuild",
     "dev": "vitest",
     "lint": "eslint --cache . && prettier -c src test examples docs",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,8 +70,8 @@ importers:
         specifier: ^3.1.2
         version: 3.1.2
       h3-nightly:
-        specifier: npm:h3-nightly@2.0.0-1721833939.ba90fcd
-        version: 2.0.0-1721833939.ba90fcd(crossws@0.2.4)
+        specifier: npm:h3-nightly@2.0.0-1721834829.5ca45e1
+        version: 2.0.0-1721834829.5ca45e1(crossws@0.2.4)
       h3-v1:
         specifier: npm:h3@^1.12.0
         version: h3@1.12.0
@@ -1693,8 +1693,8 @@ packages:
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
 
-  h3-nightly@2.0.0-1721833939.ba90fcd:
-    resolution: {integrity: sha512-sDP0LIoUo0BBL2i/DM9y0/ca7RX/FvZqC6tfKV9pfDvSbII/IDI3TUFyccWZ9Dg0VGexZNpf7F6jBp4FojNyHQ==}
+  h3-nightly@2.0.0-1721834829.5ca45e1:
+    resolution: {integrity: sha512-U13YIAv6YFrTT0ByeN9K/x2q3khtBvOwW3wFKyQaGKQ6I5Rw7purRG+sY+zLibdS6d+48EYDXGIjwYODloH+qg==}
     peerDependencies:
       crossws: ^0.2.4
     peerDependenciesMeta:
@@ -4797,7 +4797,7 @@ snapshots:
 
   graphemer@1.4.0: {}
 
-  h3-nightly@2.0.0-1721833939.ba90fcd(crossws@0.2.4):
+  h3-nightly@2.0.0-1721834829.5ca45e1(crossws@0.2.4):
     dependencies:
       cookie-es: 1.2.1
       rou3: 0.5.1

--- a/src/adapters/web/event.ts
+++ b/src/adapters/web/event.ts
@@ -85,7 +85,7 @@ const HeadersObject = /* @__PURE__ */ (() => {
 })() as unknown as { new (): H3EventContext };
 
 class WebEventResponse implements H3EventResponse {
-  _headersInit: Record<string, string> = new HeadersObject();
+  _headersInit?: Record<string, string>;
   _headers?: Headers;
 
   get headers() {
@@ -99,6 +99,9 @@ class WebEventResponse implements H3EventResponse {
     if (this._headers) {
       this._headers.set(name, value);
     } else {
+      if (!this._headersInit) {
+        this._headersInit = new HeadersObject();
+      }
       this._headersInit[name] = value;
     }
   }

--- a/src/h3.ts
+++ b/src/h3.ts
@@ -94,12 +94,12 @@ class _H3 implements H3 {
     // Prepare response
     const config = this.config;
     if (!(handlerRes instanceof Promise)) {
-      const preparedRes = prepareResponse(handlerRes, event, config);
+      const response = prepareResponse(handlerRes, event, config, true);
       return config.onBeforeResponse
-        ? Promise.resolve(config.onBeforeResponse(event, preparedRes)).then(
-            () => new Response(preparedRes.body, preparedRes),
+        ? Promise.resolve(config.onBeforeResponse(event, response)).then(
+            () => response,
           )
-        : new Response(preparedRes.body, preparedRes);
+        : response;
     }
     return handlerRes
       .catch((error) => {
@@ -111,12 +111,12 @@ class _H3 implements H3 {
           : h3Error;
       })
       .then((resolvedRes) => {
-        const preparedRes = prepareResponse(resolvedRes, event, config);
+        const response = prepareResponse(resolvedRes, event, config, true);
         return config.onBeforeResponse
-          ? Promise.resolve(config.onBeforeResponse(event, preparedRes)).then(
-              () => new Response(preparedRes.body, preparedRes),
+          ? Promise.resolve(config.onBeforeResponse(event, response)).then(
+              () => response,
             )
-          : new Response(preparedRes.body, preparedRes);
+          : response;
       });
   }
 

--- a/src/types/h3.ts
+++ b/src/types/h3.ts
@@ -27,12 +27,7 @@ export interface H3Config {
   ) => MaybePromise<void>;
 }
 
-export interface PreparedResponse {
-  status?: number;
-  statusText?: string;
-  headers?: HeadersInit;
-  body?: BodyInit | null;
-}
+export type PreparedResponse = ResponseInit & { body?: BodyInit | null };
 
 export interface WebSocketOptions {
   resolve?: crossws.ResolveHooks;

--- a/src/types/h3.ts
+++ b/src/types/h3.ts
@@ -19,11 +19,11 @@ export interface H3Config {
   onRequest?: (event: H3Event) => MaybePromise<void>;
   onBeforeResponse?: (
     event: H3Event,
-    response: PreparedResponse,
+    response: Response | PreparedResponse,
   ) => MaybePromise<void>;
   onAfterResponse?: (
     event: H3Event,
-    response?: PreparedResponse,
+    response?: Response | PreparedResponse,
   ) => MaybePromise<void>;
 }
 

--- a/test/bench/bundle.test.ts
+++ b/test/bench/bundle.test.ts
@@ -12,7 +12,7 @@ describe("benchmark", () => {
     `;
     const { bytes, gzipSize } = await getBundleSize(code);
     console.log(`Bundle size: ${bytes} (gzip: ${gzipSize})`);
-    expect(bytes).toBeLessThanOrEqual(11_000); // <11kb
+    expect(bytes).toBeLessThanOrEqual(12_000); // <12kb
     expect(gzipSize).toBeLessThanOrEqual(4000); // <4kb
   });
 });

--- a/test/hooks.test.ts
+++ b/test/hooks.test.ts
@@ -16,9 +16,9 @@ describeMatrix("hooks", (t, { it, expect }) => {
     expect(t.hooks.onError).toHaveBeenCalledTimes(0);
 
     expect(t.hooks.onBeforeResponse).toHaveBeenCalledTimes(1);
-    expect(t.hooks.onBeforeResponse.mock.calls[0]![1]!.body).toBe(
-      "Hello World!",
-    );
+    const res = t.hooks.onBeforeResponse.mock.calls[0]![1]!;
+    const resBody = res instanceof Response ? await res.text() : res.body;
+    expect(resBody).toBe("Hello World!");
 
     if (t.target !== "web") {
       expect(t.hooks.onAfterResponse).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
Normally when we return a value for h3, it tries to detect the content type and prepare a response/response-init. When users directly return a `Response` object (and have not preset any other headers or status/statusCode), we can go through a fast path optimization making handling  %3 to %6 faster.

---

But there is another part in the story. When h3 is combined with other web framework handlers that always return a `Response` object, we were blindly creating another `Response` object because it was working based on merging. 

By smarty reusing the same `Response` object, we can speed up to 2x (Bun) (%25 on Node) in performances.

<img width="683" alt="image" src="https://github.com/user-attachments/assets/6e4c3def-2ef6-4071-8a74-4167130c54b1">


---

This change also has the benefit that `onBeforeResponse` has access to the final prepared `Response` object instead of prepared `ResponseInit`