### PR TITLE
docs: add missing `parse` suffix for validation utils

### DIFF
--- a/docs/2.utils/1.request.md
+++ b/docs/2.utils/1.request.md
@@ -154,7 +154,7 @@ app.use("/", (event) => {
     event,
     z.object({
       key: z.string(),
-    }),
+    }).parse,
   );
 });
 ```
@@ -186,7 +186,7 @@ app.use("/", (event) => {
     event,
     z.object({
       key: z.string(),
-    }),
+    }).parse,
   );
 });
 ```


### PR DESCRIPTION
This PR fix #866
