### PR TITLE
fix(serveStatic): set `allow` header when responding with a `405`

### DIFF
--- a/src/utils/static.ts
+++ b/src/utils/static.ts
@@ -14,6 +14,7 @@ export async function serveStatic(
   options: ServeStaticOptions,
 ): Promise<false | undefined | null | BodyInit> {
   if (event.request.method !== "GET" && event.request.method !== "HEAD") {
+    event.response.headers.set("allow", "GET, HEAD");
     if (!options.fallthrough) {
       throw createError({
         statusMessage: "Method Not Allowed",

--- a/src/utils/static.ts
+++ b/src/utils/static.ts
@@ -14,8 +14,8 @@ export async function serveStatic(
   options: ServeStaticOptions,
 ): Promise<false | undefined | null | BodyInit> {
   if (event.request.method !== "GET" && event.request.method !== "HEAD") {
-    event.response.headers.set("allow", "GET, HEAD");
     if (!options.fallthrough) {
+      event.response.headers.set("allow", "GET, HEAD");
       throw createError({
         statusMessage: "Method Not Allowed",
         statusCode: 405,


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Allow

> This header must be sent if the server responds with a 405 Method Not Allowed status code to indicate which request methods can be used.