### PR TITLE
feat(validate): provide validate error in `cause`

### DIFF
--- a/src/utils/internal/validate.ts
+++ b/src/utils/internal/validate.ts
@@ -36,5 +36,6 @@ function createValidationError(validateError?: any) {
     statusMessage: "Validation Error",
     message: validateError?.message || "Validation Error",
     data: validateError,
+    cause: validateError,
   });
 }

--- a/test/validate.test.ts
+++ b/test/validate.test.ts
@@ -39,10 +39,10 @@ describeMatrix("validate", (t, { it, describe, expect }) => {
 
       t.app.post("/zod-caught", async (event) => {
         try {
-          await readValidatedBody(event, zodValidate)
+          await readValidatedBody(event, zodValidate);
         } catch (error_) {
-          if(isError(error_) && error_.cause instanceof ZodError) {
-            return true
+          if (isError(error_) && error_.cause instanceof ZodError) {
+            return true;
           }
         }
       });
@@ -115,7 +115,7 @@ describeMatrix("validate", (t, { it, describe, expect }) => {
           method: "POST",
           body: JSON.stringify({ invalid: true }),
         });
-        expect(await res.json()).toEqual(true);;
+        expect(await res.json()).toEqual(true);
       });
     });
   });

--- a/test/validate.test.ts
+++ b/test/validate.test.ts
@@ -1,7 +1,7 @@
 import type { ValidateFunction } from "../src/types";
 import { beforeEach } from "vitest";
-import { z } from "zod";
-import { readValidatedBody, getValidatedQuery } from "../src";
+import { z, ZodError } from "zod";
+import { readValidatedBody, getValidatedQuery, isError } from "../src";
 import { describeMatrix } from "./_setup";
 
 describeMatrix("validate", (t, { it, describe, expect }) => {
@@ -35,6 +35,16 @@ describeMatrix("validate", (t, { it, describe, expect }) => {
       t.app.post("/zod", async (event) => {
         const data = await readValidatedBody(event, zodValidate);
         return data;
+      });
+
+      t.app.post("/zod-caught", async (event) => {
+        try {
+          await readValidatedBody(event, zodValidate)
+        } catch (error_) {
+          if(isError(error_) && error_.cause instanceof ZodError) {
+            return true
+          }
+        }
       });
     });
 
@@ -98,6 +108,14 @@ describeMatrix("validate", (t, { it, describe, expect }) => {
         expect((await res.json()).data?.issues?.[0]?.code).toEqual(
           "invalid_type",
         );
+      });
+
+      it("Caught", async () => {
+        const res = await t.fetch("/zod-caught", {
+          method: "POST",
+          body: JSON.stringify({ invalid: true }),
+        });
+        expect(await res.json()).toEqual(true);;
       });
     });
   });


### PR DESCRIPTION
To be more friendly to catch third-party errors with `cause`