### PR TITLE
docs: include xForwardedFor param on getRequestIP

### DIFF
--- a/docs/2.utils/1.request.md
+++ b/docs/2.utils/1.request.md
@@ -53,7 +53,7 @@ app.use("/", (event) => {
 });
 ```
 
-### `getRequestIP(event)`
+### `getRequestIP(event, opts: { xForwardedFor? })`
 
 Try to get the client IP address from the incoming request.
 


### PR DESCRIPTION
Adds a missing parameter on the docs for `getRequestIP()`. May be worth backporting to v1 docs too.
https://github.com/unjs/h3/blob/7324eeec854eecc37422074ef9f2aec8a5e4a816/src/utils/request.ts#L297-L307
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->
