### PR TITLE
fix(proxy): ignore incoming `accept-encoding` header

### DIFF
--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -24,6 +24,7 @@ export interface ProxyOptions {
 const PayloadMethods = new Set(["PATCH", "POST", "PUT", "DELETE"]);
 const ignoredHeaders = new Set([
   "transfer-encoding",
+  "accept-encoding",
   "connection",
   "keep-alive",
   "upgrade",


### PR DESCRIPTION
Ref: https://github.com/nitrojs/nitro/issues/2880

Runtime's fetch client, might not support the encodings that the browser client supports.

The relevant issue was because Undici (Node.js) fetch does not support `zstd` but in general, it is an unsafe thing to pass through.

For performance, users can explicitly enable a supported `accept-encoding` to the server or we might later identify what runtime supports and set that instead (instead of the proxy incoming request)