### PR TITLE
docs(request): `getValidated*` utils are async

### DIFF
--- a/docs/2.utils/1.request.md
+++ b/docs/2.utils/1.request.md
@@ -138,8 +138,8 @@ You can use a simple function to validate the query object or a library like `zo
 **Example:**
 
 ```ts
-app.use("/", (event) => {
-  const query = getValidatedQuery(event, (data) => {
+app.use("/", async (event) => {
+  const query = await getValidatedQuery(event, (data) => {
     return "key" in data && typeof data.key === "string";
   });
 });
@@ -149,8 +149,8 @@ app.use("/", (event) => {
 
 ```ts
 import { z } from "zod";
-app.use("/", (event) => {
-  const query = getValidatedQuery(
+app.use("/", async (event) => {
+  const query = await getValidatedQuery(
     event,
     z.object({
       key: z.string(),
@@ -170,8 +170,8 @@ You can use a simple function to validate the params object or a library like `z
 **Example:**
 
 ```ts
-app.use("/", (event) => {
-  const params = getValidatedRouterParams(event, (data) => {
+app.use("/", async (event) => {
+  const params = await getValidatedRouterParams(event, (data) => {
     return "key" in data && typeof data.key === "string";
   });
 });
@@ -181,8 +181,8 @@ app.use("/", (event) => {
 
 ```ts
 import { z } from "zod";
-app.use("/", (event) => {
-  const params = getValidatedRouterParams(
+app.use("/", async (event) => {
+  const params = await getValidatedRouterParams(
     event,
     z.object({
       key: z.string(),

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -30,16 +30,16 @@ export function getQuery<
  * You can use a simple function to validate the query object or a library like `zod` to define a schema.
  *
  * @example
- * app.use("/", (event) => {
- *   const query = getValidatedQuery(event, (data) => {
+ * app.use("/", async (event) => {
+ *   const query = await getValidatedQuery(event, (data) => {
  *     return "key" in data && typeof data.key === "string";
  *   });
  * });
  * @example
  * import { z } from "zod";
  *
- * app.use("/", (event) => {
- *   const query = getValidatedQuery(
+ * app.use("/", async (event) => {
+ *   const query = await getValidatedQuery(
  *     event,
  *     z.object({
  *       key: z.string(),
@@ -89,16 +89,16 @@ export function getRouterParams(
  * You can use a simple function to validate the params object or a library like `zod` to define a schema.
  *
  * @example
- * app.use("/", (event) => {
- *   const params = getValidatedRouterParams(event, (data) => {
+ * app.use("/", async (event) => {
+ *   const params = await getValidatedRouterParams(event, (data) => {
  *     return "key" in data && typeof data.key === "string";
  *   });
  * });
  * @example
  * import { z } from "zod";
  *
- * app.use("/", (event) => {
- *   const params = getValidatedRouterParams(
+ * app.use("/", async (event) => {
+ *   const params = await getValidatedRouterParams(
  *     event,
  *     z.object({
  *       key: z.string(),


### PR DESCRIPTION
The functions `getValidatedQuery`and `getValidatedRouterParams` are async. This PR fixes the JSDoc examples.

<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->
