### PR TITLE
docs: fix small typo in streaming docs

### DIFF
--- a/docs/4.examples/stream-response.md
+++ b/docs/4.examples/stream-response.md
@@ -5,14 +5,14 @@
 Streaming is a powerful feature of h3. It allows you to send data to the client as soon as you have it. This is useful for large files or long running tasks.
 
 > [!WARNING]
-> Steaming is complicated and can become an overhead if you don't need it.
+> Streaming is complicated and can become an overhead if you don't need it.
 
 ## Create a Stream
 
 To stream a response, you first need to create a stream using the [`ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream) API:
 
 ```ts
-const steam = new ReadableStream();
+const stream = new ReadableStream();
 ```
 
 For the example, we will create a start function that will send a random number every 100 milliseconds. After 1000 milliseconds, it will close the stream:


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

#849 fixed one of these in the `v1` branch, but the live site seems to be showing the `main` branch content.
