### PR TITLE
fix(proxy): pass `host` for local targets

### DIFF
--- a/docs/2.utils/98.advanced.md
+++ b/docs/2.utils/98.advanced.md
@@ -117,7 +117,7 @@ Check request caching headers (`If-Modified-Since`) and add caching headers (Las
 
 Make a fetch request with the event's context and headers.
 
-### `getProxyRequestHeaders(event)`
+### `getProxyRequestHeaders(event, opts?: { host? })`
 
 Get the request headers object without headers known to cause issues when proxying.
 

--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -58,7 +58,7 @@ export async function proxyRequest(
 
   // Headers
   const fetchHeaders = mergeHeaders(
-    getProxyRequestHeaders(event),
+    getProxyRequestHeaders(event, { host: target.startsWith("/") }),
     opts.fetchOptions?.headers,
     opts.headers,
   );

--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -174,7 +174,10 @@ export async function sendProxy(
 /**
  * Get the request headers object without headers known to cause issues when proxying.
  */
-export function getProxyRequestHeaders(event: H3Event, opts?: { host?: boolean }) {
+export function getProxyRequestHeaders(
+  event: H3Event,
+  opts?: { host?: boolean },
+) {
   const headers = Object.create(null);
   const reqHeaders = getRequestHeaders(event);
   for (const name in reqHeaders) {

--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -174,11 +174,11 @@ export async function sendProxy(
 /**
  * Get the request headers object without headers known to cause issues when proxying.
  */
-export function getProxyRequestHeaders(event: H3Event) {
+export function getProxyRequestHeaders(event: H3Event, opts?: { host?: boolean }) {
   const headers = Object.create(null);
   const reqHeaders = getRequestHeaders(event);
   for (const name in reqHeaders) {
-    if (!ignoredHeaders.has(name)) {
+    if (!ignoredHeaders.has(name) || (name === "host" && opts?.host)) {
       headers[name] = reqHeaders[name];
     }
   }
@@ -202,7 +202,9 @@ export function fetchWithEvent<
     ...init,
     context: init?.context || event.context,
     headers: {
-      ...getProxyRequestHeaders(event),
+      ...getProxyRequestHeaders(event, {
+        host: typeof req === "string" && req.startsWith("/"),
+      }),
       ...init?.headers,
     },
   });


### PR DESCRIPTION
resolves nitrojs/nitro#2985

regression with https://github.com/unjs/h3/commit/d4f863f096cecea7b406301c4529da938dd1804c was that for fetching URLs with relative path (only valid for nitro direct-fetch), we were skipping `host` header.

- For external proxy, it makes sense to preserve the original host (previous fix)
- For local targets `/path` there is virtually no host, so inherit makes sense. (this fix)

This PR fixes `proxyRequest` (used by nitro proxy route rules) and `fetchWithEvent` (used by nitro `event.$fetch`)