### PR TITLE
docs(event-handler): provide clarity on package

### DIFF
--- a/docs/1.guide/2.event-handler.md
+++ b/docs/1.guide/2.event-handler.md
@@ -222,7 +222,7 @@ If you have a legacy request handler with `(req, res) => {}` syntax made for Nod
 ```js [app.mjs]
 import { createApp, fromNodeHandler } from "h3";
 
-import exampleMiddleware from "example-node-middleware";
+import exampleMiddleware from "example-node-middleware"; // This package doesn't exist, it's just an example
 
 export const app = createApp();
 


### PR DESCRIPTION
actually `example-node-middleware` does not exist. I have given a comment on it so that it provides clarity like this for "web-handler" (https://h3.unjs.io/guide/event-handler#converting-from-web-handlers). 
