### PR TITLE
docs: fix jsdoc (v1)

### DIFF
--- a/src/error.ts
+++ b/src/error.ts
@@ -17,7 +17,6 @@ import { hasProp } from "./utils/internal/object";
  * @property {boolean} unhandled - Indicates if the error was unhandled and auto captured.
  * @property {DataT} data - An extra data that will be included in the response.
  *                         This can be used to pass additional information about the error.
- * @property {boolean} internal - Setting this property to `true` will mark the error as an internal error.
  */
 export class H3Error<DataT = unknown> extends Error {
   static __h3_error__ = true;


### PR DESCRIPTION
`internal` is removed at https://github.com/unjs/h3/commit/b38d450e39101104333f33516d75869cd2427f9d#diff-39f1e030815f30ed52f7f86a69761ef60e22bbfd1521ac8d065e6d86a4bc8337L13-R71

This pull request makes the same changes to v1 as #945