### PR TITLE
docs: fix syntax and indent in handleCors example

### DIFF
--- a/docs/2.utils/98.advanced.md
+++ b/docs/2.utils/98.advanced.md
@@ -175,7 +175,7 @@ If return value is `true`, the request is handled and no further action is neede
 const app = createApp();
 const router = createRouter();
 router.use("/", async (event) => {
- const corsRes = handleCors(event, {
+  const corsRes = handleCors(event, {
     origin: "*",
     preflight: {
       statusCode: 204,
@@ -186,8 +186,7 @@ router.use("/", async (event) => {
     return corsRes;
   }
   // Your code here
- });
-);
+});
 ```
 
 ### `isCorsOriginAllowed(origin, options)`

--- a/src/utils/cors.ts
+++ b/src/utils/cors.ts
@@ -73,7 +73,7 @@ export function appendCorsHeaders(event: H3Event, options: H3CorsOptions) {
  * const app = createApp();
  * const router = createRouter();
  * router.use("/", async (event) => {
- *  const corsRes = handleCors(event, {
+ *   const corsRes = handleCors(event, {
  *     origin: "*",
  *     preflight: {
  *       statusCode: 204,
@@ -84,8 +84,7 @@ export function appendCorsHeaders(event: H3Event, options: H3CorsOptions) {
  *     return corsRes;
  *   }
  *   // Your code here
- *  });
- * );
+ * });
  */
 export function handleCors(event: H3Event, options: H3CorsOptions): false | "" {
   const _options = resolveCorsOptions(options);


### PR DESCRIPTION
The handleCors example had a stray paren and the indentation made the code difficult to read and understand.

Resolves #957.
