### PR TITLE
feat: migrate from `unenv` v1 to `node-mock-http`

### DIFF
--- a/docs/1.guide/4.event.md
+++ b/docs/1.guide/4.event.md
@@ -41,7 +41,7 @@ The main properties of an event are:
 
 ### `event.node`
 
-The `event.node` allows you to access the native Node.js request and response. In runtimes other than Node.js/Bun, h3 makes a compatible shim using [unjs/unenv](https://unenv.unjs.io).
+The `event.node` allows you to access the native Node.js request and response. In runtimes other than Node.js/Bun, h3 makes a compatible shim using [unjs/node-mock-http](https://github.com/unjs/node-mock-http).
 
 > [!IMPORTANT]
 > Try to **avoid** depending on `event.node.*` context as much as you can and instead prefer h3 utils.

--- a/package.json
+++ b/package.json
@@ -38,11 +38,11 @@
     "defu": "^6.1.4",
     "destr": "^2.0.3",
     "iron-webcrypto": "^1.2.1",
+    "node-mock-http": "^0.1.0",
     "ohash": "^1.1.4",
     "radix3": "^1.1.2",
     "ufo": "^1.5.4",
-    "uncrypto": "^0.1.3",
-    "unenv": "^1.10.0"
+    "uncrypto": "^0.1.3"
   },
   "devDependencies": {
     "0x": "^5.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       iron-webcrypto:
         specifier: ^1.2.1
         version: 1.2.1
+      node-mock-http:
+        specifier: ^0.1.0
+        version: 0.1.0
       ohash:
         specifier: ^1.1.4
         version: 1.1.4
@@ -38,9 +41,6 @@ importers:
       uncrypto:
         specifier: ^0.1.3
         version: 0.1.3
-      unenv:
-        specifier: ^1.10.0
-        version: 1.10.0
     devDependencies:
       0x:
         specifier: ^5.8.0
@@ -2688,6 +2688,9 @@ packages:
   node-forge@1.3.1:
     resolution: {integrity: sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==}
     engines: {node: '>= 6.13.0'}
+
+  node-mock-http@0.1.0:
+    resolution: {integrity: sha512-uguVoOrUjmS8VvB4CBi82WUaZrBsTvjbXk4bm8JtH/stPqNHBJoUcaGuAOWEBftflJcQkRcvkJ85pQNePrtbyA==}
 
   node-releases@2.0.19:
     resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
@@ -6638,6 +6641,8 @@ snapshots:
   node-fetch-native@1.6.6: {}
 
   node-forge@1.3.1: {}
+
+  node-mock-http@0.1.0: {}
 
   node-releases@2.0.19: {}
 

--- a/src/adapters/plain.ts
+++ b/src/adapters/plain.ts
@@ -2,7 +2,7 @@ import { IncomingMessage } from "node:http";
 import {
   IncomingMessage as NodeIncomingMessage,
   ServerResponse as NodeServerResponse,
-} from "unenv/runtime/node/http/index";
+} from "node-mock-http";
 import type { App } from "../app";
 import type { HTTPMethod } from "../types";
 import { createError, isError, sendError } from "../error";


### PR DESCRIPTION
This PR migrates from `unenv` (for Workers support) to [`node-mock-http`](https://github.com/unjs/node-mock-http) which is extracted from codebase of unenv v1.

The reason for migration is that unenv v2 will have breaking changes for `node:http` (unjs/unenv#364) and ecosystem migration is not easy.

One temporarily downside is that this causes duplicate polyfills for Nitro users however nitro (v2) will also migrate.

One benefit of this new extracted package is that we can avoid polyfills for `node:buffer` and `node:events` in Node.js runtimes (using export conditions in `node-mock-http`)