### PR TITLE
feat: add status message based on status code common errors

### DIFF
--- a/src/error.ts
+++ b/src/error.ts
@@ -136,6 +136,67 @@ export function createError<DataT = unknown>(
     err.statusMessage = sanitizeStatusMessage(statusMessage);
   }
 
+  if (!statusMessage && statusCode) {
+    switch (statusCode) {
+        case 400: {
+          err.statusMessage = "Bad Request";
+          break;
+        }
+        case 401: {
+          err.statusMessage = "Unauthorized";
+          break;
+        }
+        case 403: {
+          err.statusMessage = "Forbidden";
+          break;
+        }
+        case 404: {
+          err.statusMessage = "Not Found";
+          break;
+        }
+        case 405: {
+          err.statusMessage = "Method Not Allowed";
+          break;
+        }
+        case 408: {
+          err.statusMessage = "Request Timeout";
+          break;
+        }
+        case 409: {
+          err.statusMessage = "Conflict";
+          break;
+        }
+        case 422: {
+          err.statusMessage = "Unprocessable Content"
+          break;
+        }
+        case 429: {
+          err.statusMessage = "Too Many Request";
+          break;
+        }
+        case 500: {
+          err.statusMessage = "Internal Server Error";
+          break;
+        }
+        case 501: {
+          err.statusMessage = "Not Implemented";
+          break;
+        }
+        case 502: {
+          err.statusMessage = "Bad Gateway";
+          break;
+        }
+        case 503: {
+          err.statusMessage = "Service Unavailable";
+          break;
+        }
+        case 504: {
+          err.statusMessage = "Gateway Timeout";
+          break;
+        }
+      }
+  }
+
   const fatal = input.fatal ?? (cause as H3Error)?.fatal;
   if (fatal !== undefined) {
     err.fatal = fatal;

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -123,4 +123,14 @@ describeMatrix("errors", (t, { it, expect }) => {
 
     t.errors = [];
   });
+
+  it("should set default statusMessage for 400", async () => {
+    t.app.get("/", () => {
+      throw createError({ statusCode: 400 });
+    });
+
+    const res = await t.fetch("/");
+    expect(res.status).toBe(400);
+    expect(t.errors[0].statusMessage).toBe("Bad Request");
+  });
 });


### PR DESCRIPTION
as the title say, i just add default statusMessage based on statusCode, i kinda not like that statusMessage is always empty and must explicitly add in any createError to show it up. especially in Nuxt server api response.

assume we have some error :
```js
} catch (error : any) {
    // return fields error and it message if validation error but not with statusMessage "Bad Request"
    if (error instanceof ValidationError) {
        throw createError({
           statusCode: 400,
           message: "Validation Error",
           data: {
             field: 'error message',
             // ...another error
          });
    }
    // return error 500 with Internal Server Error status message
   throw createError({
      statusCode: 500,
      statusMessage: "Internal Server Error",
      message: "Internal Server Error"
    });
}
```
with default statusMessage, we not have to explicitly add statusMessage on any createError, default statusMessage with handle it.

```js
throw createError({
  statusCode: 400,
  message: "Validation Error",
  data: {
    field: 'error message',
    // ...another error
});

// response HTTP
{
  statusCode: 400,
  statusMessage: "Bad Request"
  // ... another field
}
```
just reducing unnecessary repetition for good http responses...

with ```pnpm dev``` for testing any errors :

![image](https://github.com/user-attachments/assets/4938d022-3ff8-447e-88e5-cde5e50437aa)
