### PR TITLE
fix: properly merge headers in fetchWithEvent

### DIFF
--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -166,11 +166,11 @@ export function fetchWithEvent<
   return getFetch(options?.fetch)(req, <RequestInit>{
     ...init,
     context: init?.context || event.context,
-    headers: {
-      ...getProxyRequestHeaders(event, {
+    headers: mergeHeaders(
+      getProxyRequestHeaders(event, {
         host: typeof req === "string" && req.startsWith("/"),
       }),
-      ...init?.headers,
-    },
+      init?.headers,
+    ),
   });
 }


### PR DESCRIPTION
fixes https://github.com/nuxt/nuxt/issues/31073

Currently, the merging behavior is inconsistent between useRequestFetch and client $fetch because of spreading headers without normalization. This PR fixes that by doing essentially same as what's done above in that file:

https://github.com/unjs/h3/blob/0a796ff1b8b570791386045881ca739942065460/src/utils/proxy.ts#L37-L42