### PR TITLE
feat: use JWE internally to `useSession`

### DIFF
--- a/src/types/utils/session.ts
+++ b/src/types/utils/session.ts
@@ -1,5 +1,5 @@
 import type { CookieSerializeOptions } from "cookie-es";
-import type { SealOptions } from "../../utils/internal/iron-crypto";
+import type { JWEOptions } from "../../utils/internal/jwe";
 import type { kGetSession } from "../../utils/internal/session";
 
 type SessionDataT = Record<string, any>;
@@ -24,7 +24,8 @@ export interface SessionConfig {
   cookie?: false | CookieSerializeOptions;
   /** Default is x-h3-session / x-{name}-session */
   sessionHeader?: false | string;
-  seal?: SealOptions;
+  /** JWE options for encryption/decryption */
+  jwe?: Partial<JWEOptions>;
   crypto?: Crypto;
   /** Default is Crypto.randomUUID */
   generateId?: () => string;

--- a/src/utils/internal/jwe.ts
+++ b/src/utils/internal/jwe.ts
@@ -213,6 +213,10 @@ export async function unseal(
   }
 
   // Check expiration
+  if (result.exp && typeof result.exp !== "number") {
+    throw new Error("Invalid expiration");
+  }
+
   if (result.exp && result.exp <= now - opts.timestampSkewSec * 1000) {
     throw new Error("Token expired");
   }

--- a/src/utils/internal/jwe.ts
+++ b/src/utils/internal/jwe.ts
@@ -1,0 +1,221 @@
+import crypto from "uncrypto";
+import {
+  base64Decode,
+  base64Encode,
+  textDecoder,
+  textEncoder,
+} from "./encoding";
+
+/**
+ * JWE (JSON Web Encryption) implementation for H3 sessions
+ */
+
+export interface JWEOptions {
+  /** Expiration time in milliseconds where 0 means forever. Defaults to 0. */
+  ttl: number;
+  /** Number of seconds of permitted clock skew for incoming expirations. Defaults to 60 seconds. */
+  timestampSkewSec: number;
+  /** Local clock time offset in milliseconds. Defaults to 0. */
+  localtimeOffsetMsec: number;
+}
+
+export const DEFAULT_JWE_OPTIONS: JWEOptions = {
+  ttl: 0,
+  timestampSkewSec: 60,
+  localtimeOffsetMsec: 0,
+};
+
+export interface JWEHeader {
+  alg: string;
+  enc: string;
+}
+
+export interface JWESegments {
+  protected: string;
+  iv: string;
+  ciphertext: string;
+  tag: string;
+}
+
+/**
+ * Encrypt and serialize data into a JWE token
+ */
+export async function seal(
+  payload: unknown,
+  password: string,
+  options: Partial<JWEOptions> = {},
+): Promise<string> {
+  if (!password || typeof password !== "string") {
+    throw new Error("Invalid password");
+  }
+
+  const opts = { ...DEFAULT_JWE_OPTIONS, ...options };
+  const now = Date.now() + opts.localtimeOffsetMsec;
+
+  // Add expiration if ttl is provided
+  const payloadWithMeta = {
+    payload,
+    iat: now,
+    ...(opts.ttl ? { exp: now + opts.ttl } : {}),
+  };
+
+  // Generate a random IV and salt
+  const iv = crypto.getRandomValues(new Uint8Array(16));
+  const salt = crypto.getRandomValues(new Uint8Array(16));
+
+  // Key derivation
+  const keyMaterial = await crypto.subtle.importKey(
+    "raw",
+    textEncoder.encode(password),
+    { name: "PBKDF2" },
+    false,
+    ["deriveBits", "deriveKey"],
+  );
+
+  const key = await crypto.subtle.deriveKey(
+    {
+      name: "PBKDF2",
+      salt,
+      iterations: 100_000,
+      hash: "SHA-256",
+    },
+    keyMaterial,
+    { name: "AES-GCM", length: 256 },
+    false,
+    ["encrypt"],
+  );
+
+  // Create protected header
+  const protectedHeader: JWEHeader = {
+    alg: "PBES2-HS256+A128KW",
+    enc: "A256GCM",
+  };
+
+  const protectedHeaderB64 = base64Encode(JSON.stringify(protectedHeader));
+
+  // Encrypt payload
+  const plaintext = textEncoder.encode(JSON.stringify(payloadWithMeta));
+  const encryptedData = await crypto.subtle.encrypt(
+    {
+      name: "AES-GCM",
+      iv,
+      tagLength: 128,
+    },
+    key,
+    plaintext,
+  );
+
+  // Split ciphertext and authentication tag
+  const encryptedDataArray = new Uint8Array(encryptedData);
+  const ciphertextLength = encryptedDataArray.length - 16; // Last 16 bytes are the auth tag
+  const ciphertext = encryptedDataArray.slice(0, ciphertextLength);
+  const tag = encryptedDataArray.slice(ciphertextLength);
+
+  // Format as compact JWE: header.salt.iv.ciphertext.tag
+  return `${protectedHeaderB64}.${base64Encode(salt)}.${base64Encode(iv)}.${base64Encode(ciphertext)}.${base64Encode(tag)}`;
+}
+
+/**
+ * Decrypt and verify a JWE token
+ */
+export async function unseal(
+  token: string,
+  password: string,
+  options: Partial<JWEOptions> = {},
+): Promise<unknown> {
+  if (!password || typeof password !== "string") {
+    throw new Error("Invalid password");
+  }
+
+  const opts = { ...DEFAULT_JWE_OPTIONS, ...options };
+  const now = Date.now() + opts.localtimeOffsetMsec;
+
+  // Split the JWE token
+  const parts = token.split(".");
+  if (parts.length !== 5) {
+    throw new Error("Invalid JWE token format");
+  }
+
+  const [protectedHeaderB64, saltB64, ivB64, ciphertextB64, tagB64] = parts;
+
+  // Decode and validate protected header
+  let protectedHeader: JWEHeader;
+  try {
+    protectedHeader = JSON.parse(
+      textDecoder.decode(base64Decode(protectedHeaderB64)),
+    ) as JWEHeader;
+  } catch {
+    throw new Error("Invalid JWE header");
+  }
+
+  if (
+    protectedHeader.alg !== "PBES2-HS256+A128KW" ||
+    protectedHeader.enc !== "A256GCM"
+  ) {
+    throw new Error("Unsupported JWE algorithms");
+  }
+
+  // Reconstruct the key
+  const salt = base64Decode(saltB64);
+  const iv = base64Decode(ivB64);
+  const ciphertext = base64Decode(ciphertextB64);
+  const tag = base64Decode(tagB64);
+
+  // Combine ciphertext and tag for decryption
+  const encryptedData = new Uint8Array(ciphertext.length + tag.length);
+  encryptedData.set(ciphertext);
+  encryptedData.set(tag, ciphertext.length);
+
+  // Derive key
+  const keyMaterial = await crypto.subtle.importKey(
+    "raw",
+    textEncoder.encode(password),
+    { name: "PBKDF2" },
+    false,
+    ["deriveBits", "deriveKey"],
+  );
+
+  const key = await crypto.subtle.deriveKey(
+    {
+      name: "PBKDF2",
+      salt,
+      iterations: 100_000,
+      hash: "SHA-256",
+    },
+    keyMaterial,
+    { name: "AES-GCM", length: 256 },
+    false,
+    ["decrypt"],
+  );
+
+  // Decrypt
+  let decrypted;
+  try {
+    decrypted = await crypto.subtle.decrypt(
+      {
+        name: "AES-GCM",
+        iv,
+        tagLength: 128,
+      },
+      key,
+      encryptedData,
+    );
+  } catch {
+    throw new Error("Failed to decrypt JWE token");
+  }
+
+  // Parse and validate
+  let result;
+  try {
+    result = JSON.parse(textDecoder.decode(decrypted));
+  } catch {
+    throw new Error("Invalid JWE payload format");
+  }
+
+  // Check expiration
+  if (result.exp && result.exp <= now - opts.timestampSkewSec * 1000) {
+    throw new Error("Token expired");
+  }
+
+  return result.payload;
+}

--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -1,5 +1,5 @@
 import type { H3Event, Session, SessionConfig, SessionData } from "../types";
-import { seal, unseal, defaults as sealDefaults } from "./internal/iron-crypto";
+import { seal, unseal, DEFAULT_JWE_OPTIONS } from "./internal/jwe";
 import { getCookie, setCookie } from "./cookie";
 import {
   DEFAULT_SESSION_NAME,
@@ -163,9 +163,9 @@ export async function sealSession<T extends SessionData = SessionData>(
     (await getSession<T>(event, config));
 
   const sealed = await seal(session, config.password, {
-    ...sealDefaults,
+    ...DEFAULT_JWE_OPTIONS,
     ttl: config.maxAge ? config.maxAge * 1000 : 0,
-    ...config.seal,
+    ...config.jwe,
   });
 
   return sealed;
@@ -180,9 +180,9 @@ export async function unsealSession(
   sealed: string,
 ) {
   const unsealed = (await unseal(sealed, config.password, {
-    ...sealDefaults,
+    ...DEFAULT_JWE_OPTIONS,
     ttl: config.maxAge ? config.maxAge * 1000 : 0,
-    ...config.seal,
+    ...config.jwe,
   })) as Partial<Session>;
   if (config.maxAge) {
     const age = Date.now() - (unsealed.createdAt || Number.NEGATIVE_INFINITY);

--- a/test/unit/jwe.test.ts
+++ b/test/unit/jwe.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, assert } from "vitest";
+import * as JWE from "../../src/utils/internal/jwe";
+
+const testObject = { a: 1, b: 2, c: [3, 4, 5], d: { e: "f" } };
+const password = "some_not_random_password_that_is_also_long_enough";
+
+describe("JWE", () => {
+  it("seals and unseals an object correctly", async () => {
+    const sealed = await JWE.seal(testObject, password);
+    const unsealed = await JWE.unseal(sealed, password);
+    assert.deepEqual(unsealed, testObject);
+  });
+
+  it("handles expiration correctly", async () => {
+    // Set a 100ms expiration
+    const options = { ttl: 100 };
+    const sealed = await JWE.seal(testObject, password, options);
+
+    // Should work immediately
+    const unsealed = await JWE.unseal(sealed, password, options);
+    assert.deepEqual(unsealed, testObject);
+
+    // Should fail after expiration
+    await new Promise((resolve) => setTimeout(resolve, 110));
+    await expect(JWE.unseal(sealed, password, options)).rejects.toThrow(
+      "Token expired",
+    );
+  });
+
+  it("handles time offset correctly", async () => {
+    // Set a 100ms expiration with time offset into the future
+    const options = { ttl: 100, localtimeOffsetMsec: 200 };
+    const sealed = await JWE.seal(testObject, password, options);
+
+    // Should work with the same offset
+    const unsealed = await JWE.unseal(sealed, password, options);
+    assert.deepEqual(unsealed, testObject);
+
+    // Should fail with a different offset that puts us past expiration
+    await expect(
+      JWE.unseal(sealed, password, { ttl: 100, localtimeOffsetMsec: 300 }),
+    ).rejects.toThrow("Token expired");
+  });
+
+  it("handles timestamp skew correctly", async () => {
+    // Set a very short expiration
+    const options = { ttl: 1 };
+    const sealed = await JWE.seal(testObject, password, options);
+
+    // Wait for expiration
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // Should still work with increased skew tolerance
+    const unsealed = await JWE.unseal(sealed, password, {
+      ...options,
+      timestampSkewSec: 10,
+    });
+    assert.deepEqual(unsealed, testObject);
+  });
+
+  it("rejects invalid passwords", async () => {
+    const sealed = await JWE.seal(testObject, password);
+
+    await expect(JWE.unseal(sealed, "wrong_password")).rejects.toThrow(
+      "Failed to decrypt JWE token",
+    );
+
+    await expect(JWE.seal(testObject, "")).rejects.toThrow("Invalid password");
+
+    await expect(JWE.unseal(sealed, "")).rejects.toThrow("Invalid password");
+  });
+
+  it("rejects invalid JWE formats", async () => {
+    await expect(JWE.unseal("invalid.jwe.token", password)).rejects.toThrow(
+      "Invalid JWE token format",
+    );
+
+    await expect(
+      JWE.unseal("part1.part2.part3.part4.part5.extrastuff", password),
+    ).rejects.toThrow("Invalid JWE token format");
+  });
+
+  it("rejects tampered tokens", async () => {
+    const sealed = await JWE.seal(testObject, password);
+    const parts = sealed.split(".");
+
+    // Tamper with the ciphertext
+    const tamperedSeal = [
+      parts[0],
+      parts[1],
+      parts[2],
+      parts[3] + "x", // tamper with ciphertext
+      parts[4],
+    ].join(".");
+
+    await expect(JWE.unseal(tamperedSeal, password)).rejects.toThrow(
+      "Failed to decrypt JWE token",
+    );
+
+    // Tamper with the tag
+    const tamperedTag = [
+      parts[0],
+      parts[1],
+      parts[2],
+      parts[3],
+      parts[4] + "x", // tamper with tag
+    ].join(".");
+
+    await expect(JWE.unseal(tamperedTag, password)).rejects.toThrow(
+      "Failed to decrypt JWE token",
+    );
+  });
+
+  it("rejects invalid JWE header", async () => {
+    const sealed = await JWE.seal(testObject, password);
+    const parts = sealed.split(".");
+
+    // Replace header with invalid base64
+    const invalidHeader = [
+      "!@#$%^", // invalid base64
+      parts[1],
+      parts[2],
+      parts[3],
+      parts[4],
+    ].join(".");
+
+    await expect(JWE.unseal(invalidHeader, password)).rejects.toThrow(
+      "Invalid JWE header",
+    );
+  });
+
+  it("rejects unsupported algorithms", async () => {
+    const sealed = await JWE.seal(testObject, password);
+    const parts = sealed.split(".");
+
+    // Create a header with unsupported algorithm
+    const invalidAlgHeader = base64Encode(
+      JSON.stringify({
+        alg: "unsupported",
+        enc: "A256GCM",
+      }),
+    );
+
+    const invalidAlgJWE = [
+      invalidAlgHeader,
+      parts[1],
+      parts[2],
+      parts[3],
+      parts[4],
+    ].join(".");
+
+    await expect(JWE.unseal(invalidAlgJWE, password)).rejects.toThrow(
+      "Unsupported JWE algorithms",
+    );
+  });
+
+  it("handles complex nested objects", async () => {
+    const complexObj = {
+      array: [1, 2, 3, 4, 5],
+      nested: {
+        a: { b: { c: { d: { e: "deep" } } } },
+        arr: [
+          [1, 2],
+          [3, 4],
+        ],
+      },
+      date: new Date().toISOString(),
+      nullValue: null,
+      booleans: [true, false],
+    };
+
+    const sealed = await JWE.seal(complexObj, password);
+    const unsealed = await JWE.unseal(sealed, password);
+    assert.deepEqual(unsealed, complexObj);
+  });
+
+  it("handles empty objects", async () => {
+    const sealed = await JWE.seal({}, password);
+    const unsealed = await JWE.unseal(sealed, password);
+    assert.deepEqual(unsealed, {});
+  });
+});
+
+// Helper function for encoding
+function base64Encode(input: string): string {
+  return btoa(input).replace(/=/g, "").replace(/\+/g, "-").replace(/\//g, "_");
+}


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

Related to #994

This is a first implementation to use `JWE` ([RFC7516](https://datatracker.ietf.org/doc/html/rfc7516)) instead of `iron-crypto` as the internal `useSession` encryption.

The main goal is to provide better support for cross-platform/cross-language support in scenarios like edge networks and proxies.