### PR TITLE
fix: Support for nested BigInt serialization through JSON replacer

### DIFF
--- a/src/response.ts
+++ b/src/response.ts
@@ -2,7 +2,7 @@ import type { H3Config, H3Event } from "./types";
 import type { H3Error } from "./types/h3";
 import { Response as SrvxResponse } from "srvx";
 import { createError } from "./error";
-import { isJSONSerializable } from "./utils/internal/object";
+import { isJSONSerializable, responseReplacer } from "./utils/internal/object";
 
 export const kNotFound = /* @__PURE__ */ Symbol.for("h3.notFound");
 export const kHandled = /* @__PURE__ */ Symbol.for("h3.handled");
@@ -135,7 +135,7 @@ function prepareResponseBody(
   // JSON
   if (isJSONSerializable(val, valType)) {
     return {
-      body: JSON.stringify(val, undefined, config.debug ? 2 : undefined),
+      body: JSON.stringify(val, responseReplacer, config.debug ? 2 : undefined),
       headers: jsonHeaders,
     };
   }

--- a/src/utils/internal/object.ts
+++ b/src/utils/internal/object.ts
@@ -14,6 +14,14 @@ export function hasProp(obj: any, prop: string | symbol) {
   }
 }
 
+export function responseReplacer(key: string, val: any) {
+  // Filtering types
+  if (typeof val === "bigint") {
+    return val.toString();
+  }
+  return val;
+}
+
 export function isJSONSerializable(value: any, _type: string): boolean {
   // Primitive values are JSON serializable
   if (value === null || value === undefined) {

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -17,6 +17,13 @@ describeMatrix("app", (t, { it, expect }) => {
     expect(await res.text()).toBe("9007199254740991");
   });
 
+  it("can return bigint nested", async () => {
+    t.app.use("/", () => ({ myBigInt: BigInt(9_007_199_254_740_991), nested: { myBigInt2: BigInt(9_007_199_254_740_991) } }));
+    const res = await t.fetch("/");
+
+    expect(await res.json()).toEqual({ myBigInt: "9007199254740991", nested: { myBigInt2: "9007199254740991" } });
+  });
+
   it("returning symbol or function", async () => {
     t.app.get("/fn", () => {
       return function test() {};


### PR DESCRIPTION
Closed https://github.com/unjs/h3/pull/1007 because of mistakes. I redid this and updated it to reflect the latest changes.

Original issue here https://github.com/unjs/h3/issues/474 and mine https://github.com/unjs/h3/issues/995

I created a test for it as well. Appears to satisfy the use case (and hopefully others). I left the replacer open ended. I noticed that this would potentially solve a small oversight with the ```isJSONSerializable``` function since it does not check for serializable primitives nested inside of Arrays/Objects. 