### PR TITLE
fix playground

### DIFF
--- a/playground/app.ts
+++ b/playground/app.ts
@@ -1,0 +1,13 @@
+import { createApp, createRouter, eventHandler } from "h3";
+
+export const app = createApp();
+
+const router = createRouter();
+app.use(router);
+
+router.get(
+  "/",
+  eventHandler((event) => {
+    return { path: event.path, message: "Hello World!" };
+  }),
+);


### PR DESCRIPTION
resolves #1015

This PR adds the `app.ts` back to the playground so it works again on StackBlitz.
