### PR TITLE
feat: expose `H3Event.app`

### DIFF
--- a/docs/1.guide/900.api/2.h3event.md
+++ b/docs/1.guide/900.api/2.h3event.md
@@ -59,6 +59,10 @@ export async function logRequest(request) {
 
 ## `H3Event` Properties
 
+### `H3Event.app?`
+
+Access to the H3 [application instance](/guide/api/h3).
+
 ### `H3Event.context`
 
 The context is an object that contains arbitrary information about the request.

--- a/src/event.ts
+++ b/src/event.ts
@@ -7,10 +7,16 @@ import type {
   EventHandlerRequest,
   TypedServerRequest,
 } from "./types/handler.ts";
+import type { H3Core } from "./h3.ts";
 
 export class H3Event<
   _RequestT extends EventHandlerRequest = EventHandlerRequest,
 > {
+  /**
+   * Access to the H3 application instance.
+   */
+  app?: H3Core;
+
   /**
    * Incoming HTTP request info.
    *
@@ -40,9 +46,10 @@ export class H3Event<
    */
   _res?: H3EventResponse;
 
-  constructor(req: ServerRequest, context?: H3EventContext) {
+  constructor(req: ServerRequest, context?: H3EventContext, app?: H3Core) {
     this.context = context || new EmptyObject();
     this.req = req;
+    this.app = app;
     // Parsed URL can be provided by srvx (node) and other runtimes
     const _url = (req as { _url?: URL })._url;
     this.url = _url && _url instanceof URL ? _url : new FastURL(req.url);

--- a/src/h3.ts
+++ b/src/h3.ts
@@ -16,6 +16,8 @@ import type {
 } from "./types/h3.ts";
 import type { ServerRequest } from "srvx";
 
+export type H3Core = H3Type;
+
 export const H3Core = /* @__PURE__ */ (() => {
   // prettier-ignore
   const HTTPMethods = ["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS", "CONNECT", "TRACE" ] as const;
@@ -57,7 +59,7 @@ export const H3Core = /* @__PURE__ */ (() => {
       const request: ServerRequest = toRequest(_req, _init);
 
       // Create a new event instance
-      const event = new H3Event(request, context);
+      const event = new H3Event(request, context, this as unknown as H3Type);
 
       // Execute the handler
       let handlerRes: unknown | Promise<unknown>;


### PR DESCRIPTION
This PR exposes `h3.app?` (optional) 

This allows:
- Access to global config (resolves #694)
   - Unblocks global session config support (#693)
- Having `event.app.fetch` for internal fetch (resolves #1134)

Concerns: Exposing a global app instance might allow side effects from handlers, which makes the global app unpredictable. We likely need to freeze routes and config at least after serve method (upcoming PR)