### PR TITLE
fix(getRequestHost): return first host from `x-forwarded-host`

### DIFF
--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -277,7 +277,10 @@ export function getRequestHost(
   opts: { xForwardedHost?: boolean } = {},
 ) {
   if (opts.xForwardedHost) {
-    const xForwardedHost = event.node.req.headers["x-forwarded-host"] as string;
+    const _header = event.node.req.headers["x-forwarded-host"] as
+      | string
+      | undefined;
+    const xForwardedHost = (_header || "").split(",").shift()?.trim();
     if (xForwardedHost) {
       return xForwardedHost;
     }


### PR DESCRIPTION
resolves https://github.com/h3js/h3/issues/1173

This PR backports https://github.com/h3js/h3/pull/993 to `v1`. ❤️