### PR TITLE
chore(docs): lowercase `srvx`

### DIFF
--- a/docs/1.guide/0.index.md
+++ b/docs/1.guide/0.index.md
@@ -100,7 +100,7 @@ serve(app, { port: 3000 });
 ```
 
 > [!TIP]
-> The `serve` method is powered by [💥 Srvx](https://srvx.h3.dev/), a runtime-agnostic universal server listener based on web standards that works seamlessly with [Deno](https://deno.com/), [Node.js](https://nodejs.org/) and [Bun](https://bun.sh/).
+> The `serve` method is powered by [💥 srvx](https://srvx.h3.dev/), a runtime-agnostic universal server listener based on web standards that works seamlessly with [Deno](https://deno.com/), [Node.js](https://nodejs.org/) and [Bun](https://bun.sh/).
 
 We also have [`app.fetch`](/guide/api/h3#h3fetch) which can be directly used to run H3 apps in any web-compatible runtime or even directly called for testing purposes.
 

--- a/docs/99.blog/2.v2-beta.md
+++ b/docs/99.blog/2.v2-beta.md
@@ -26,7 +26,7 @@ Thanks to evolving web standards by initiatives like [WinterTC](https://wintertc
 - Leverage more of runtime native primitives like (Request, URL, Headers, etc.)
 - Easier API testing
 
-## 💥 Srvx: Universal Web Server API
+## 💥 srvx: Universal Web Server API
 
 A major challenge was that Node.js lacks built-in support for web-standard HTTP servers. For `node:http` compatibility, an adapter is needed to bridge Node.js `IncomingMessage` to web `Request`, and to handle web `Response` via Node.js `ServerResponse`. We have implemented a [compatibility layer](https://srvx.h3.dev/guide/node) that bridges interfaces and achieves **up to 96.98% of native `node:http` performance** (see [benchmarks](https://github.com/h3js/srvx/tree/main/test/bench-node)).
 


### PR DESCRIPTION
I think `srvx` is always with lowercase in all letters.