### PR TITLE
types: merge `body` to `HTTPError.toJSON` type

### DIFF
--- a/src/error.ts
+++ b/src/error.ts
@@ -232,7 +232,7 @@ export class HTTPError<DataT = unknown>
     return this.statusText;
   }
 
-  toJSON(): ErrorBody {
+  toJSON(): Omit<ErrorBody, "body"> & ErrorBody["body"] {
     const unhandled = this.unhandled;
     return {
       status: this.status,


### PR DESCRIPTION
Fixes the `HTTPError::toJSON` response type.