### PR TITLE
docs: remove beta tag

### DIFF
--- a/docs/1.guide/0.index.md
+++ b/docs/1.guide/0.index.md
@@ -35,7 +35,7 @@ All utilities, share an [H3Event](/guide/api/h3event) context.
 
 Install `h3` as a dependency:
 
-:pm-install{name="h3@beta"}
+:pm-install{name="h3"}
 
 Create a new file for server entry:
 
@@ -119,7 +119,7 @@ console.log(await response.text());
 You can directly import `h3` library from CDN alternatively. This method can be used for Bun, Deno and other runtimes such as Cloudflare Workers.
 
 ```js
-import { H3 } from "https://esm.sh/h3@beta";
+import { H3 } from "https://esm.sh/h3";
 
 const app = new H3().get("/", () => "⚡️ Tadaa!");
 


### PR DESCRIPTION
recently I used h3 and i did not need to write h3@beta. it automatically install h3 v.2, that is why I've thought maybe we can remove h3@beta now. 