### PR TITLE
refactor(proxy)!: keep header entries as-is

### DIFF
--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -98,7 +98,7 @@ export async function proxy(
       cookies.push(value);
       continue;
     }
-    headers.set(key, value);
+    headers.append(key, value);
   }
 
   if (cookies.length > 0) {


### PR DESCRIPTION
Simiar to https://github.com/h3js/srvx/pull/127

Proxy upstream should properly send multi value headers in seperate lines. 

This change makes tracing issues easier also fixes to support (other) multi entry values.