### PR TITLE
refactor!: slim down `H3Core`

### DIFF
--- a/test/bench/bundle.test.ts
+++ b/test/bench/bundle.test.ts
@@ -38,8 +38,8 @@ describe("benchmark", () => {
         `Bundle size (H3Core): ${bundle.bytes} (gzip: ${bundle.gzipSize})`,
       );
     }
-    expect(bundle.bytes).toBeLessThanOrEqual(7900); // <7.9kb
-    expect(bundle.gzipSize).toBeLessThanOrEqual(3100); // <3.1kb
+    expect(bundle.bytes).toBeLessThanOrEqual(6200); // <6.2kb
+    expect(bundle.gzipSize).toBeLessThanOrEqual(2500); // <2.5kb
   });
 
   it("bundle size (defineHandler)", async () => {


### PR DESCRIPTION
`H3Core` class (undocumented) is the bare minimum H3 interface and used/extended by Nitro internally together with compiled router and pre-normalized middleware.

While testing, many of utils can be left unused in bundle. 

This PR slims `H3Core` down to 2 essential methods: (reducing `-1.7kB` => `6.2kB`)
- `fetch`
- `handler`

+  [constructor] and Internal `_request` that is used by `H3` super class and `_findRoute`/`_addRoute`/`_getMiddleware` which are implemented by user.