### PR TITLE
refactor: hide internals with `~` for better dx

### DIFF
--- a/src/_entries/_common.ts
+++ b/src/_entries/_common.ts
@@ -4,7 +4,7 @@ export function freezeApp(app: H3): void {
   // @ts-expect-error
   app.config = Object.freeze(app.config);
 
-  app._addRoute = () => {
+  app["~addRoute"] = () => {
     throw new Error("Cannot add routes after the server init.");
   };
 }

--- a/src/h3.ts
+++ b/src/h3.ts
@@ -29,23 +29,39 @@ import { toEventHandler } from "./handler.ts";
 export const NoHandler: EventHandler = () => kNotFound;
 
 export class H3Core implements H3CoreType {
-  _middleware: Middleware[];
-  _routes: H3Route[] = [];
-
   readonly config: H3CoreConfig;
 
+  "~middleware": Middleware[];
+  "~routes": H3Route[] = [];
+
   constructor(config: H3CoreConfig = {}) {
-    this._middleware = [];
+    this["~middleware"] = [];
     this.config = config;
     this.fetch = this.fetch.bind(this);
     this.handler = this.handler.bind(this);
   }
 
   fetch(request: ServerRequest): Response | Promise<Response> {
-    return this._request(request);
+    return this["~request"](request);
   }
 
-  _request(
+  handler(event: H3Event): unknown | Promise<unknown> {
+    const route = this["~findRoute"](event);
+    if (route) {
+      event.context.params = route.params;
+      event.context.matchedRoute = route.data;
+    }
+    const routeHandler = route?.data.handler || NoHandler;
+    const middleware = this["~getMiddleware"](
+      event,
+      route as unknown as undefined,
+    );
+    return middleware.length > 0
+      ? callMiddleware(event, middleware, routeHandler)
+      : routeHandler(event);
+  }
+
+  "~request"(
     request: ServerRequest,
     context?: H3EventContext,
   ): Response | Promise<Response> {
@@ -72,46 +88,31 @@ export class H3Core implements H3CoreType {
     return toResponse(handlerRes, event, this.config);
   }
 
-  _findRoute(_event: H3Event): MatchedRoute<H3Route> | void {}
+  "~findRoute"(_event: H3Event): MatchedRoute<H3Route> | void {}
 
-  _addRoute(_route: H3Route): void {
-    this._routes.push(_route);
+  "~addRoute"(_route: H3Route): void {
+    this["~routes"].push(_route);
   }
 
-  _getMiddleware(
+  "~getMiddleware"(
     _event: H3Event,
     route: MatchedRoute<H3Route> | undefined,
   ): Middleware[] {
     const routeMiddleware = route?.data.middleware;
+    const globalMiddleware = this["~middleware"];
     return routeMiddleware
-      ? [...this._middleware, ...routeMiddleware]
-      : this._middleware;
-  }
-
-  handler(event: H3Event): unknown | Promise<unknown> {
-    const route = this._findRoute(event);
-    if (route) {
-      event.context.params = route.params;
-      event.context.matchedRoute = route.data;
-    }
-    const routeHandler = route?.data.handler || NoHandler;
-    const middleware = this._getMiddleware(
-      event,
-      route as unknown as undefined,
-    );
-    return middleware.length > 0
-      ? callMiddleware(event, middleware, routeHandler)
-      : routeHandler(event);
+      ? [...globalMiddleware, ...routeMiddleware]
+      : globalMiddleware;
   }
 }
 
 export const H3 = /* @__PURE__ */ (() => {
   class H3 extends H3Core {
-    _rou3: RouterContext<H3Route>;
+    "~rout3": RouterContext<H3Route>;
 
     constructor(config: H3Config = {}) {
       super(config);
-      this._rou3 = createRouter();
+      this["~rout3"] = createRouter();
       this.request = this.request.bind(this);
       config.plugins?.forEach((plugin) => plugin(this as unknown as H3Type));
     }
@@ -126,26 +127,26 @@ export const H3 = /* @__PURE__ */ (() => {
       _init?: RequestInit,
       context?: H3EventContext,
     ): Response | Promise<Response> {
-      return this._request(toRequest(_req, _init), context);
+      return this["~request"](toRequest(_req, _init), context);
     }
 
     mount(base: string, input: FetchHandler | FetchableObject | H3Type) {
       if ("handler" in input) {
-        if (input._middleware.length > 0) {
-          this._middleware.push((event, next) => {
+        if (input["~middleware"].length > 0) {
+          this["~middleware"].push((event, next) => {
             const originalPathname = event.url.pathname;
             if (!originalPathname.startsWith(base)) {
               return next();
             }
             event.url.pathname = event.url.pathname.slice(base.length) || "/";
-            return callMiddleware(event, input._middleware, () => {
+            return callMiddleware(event, input["~middleware"], () => {
               event.url.pathname = originalPathname;
               return next();
             });
           });
         }
-        for (const r of input._routes) {
-          this._addRoute({
+        for (const r of input["~routes"]) {
+          this["~addRoute"]({
             ...r,
             route: base + r.route,
           });
@@ -169,7 +170,7 @@ export const H3 = /* @__PURE__ */ (() => {
     ): this {
       const _method = (method || "").toUpperCase();
       route = new URL(route, "http://_").pathname;
-      this._addRoute({
+      this["~addRoute"]({
         method: _method as HTTPMethod,
         route,
         handler: toEventHandler(handler)!,
@@ -183,13 +184,13 @@ export const H3 = /* @__PURE__ */ (() => {
       return this.on("", route, handler, opts);
     }
 
-    override _findRoute(_event: H3Event): MatchedRoute<H3Route> | void {
-      return findRoute(this._rou3, _event.req.method, _event.url.pathname);
+    override "~findRoute"(_event: H3Event): MatchedRoute<H3Route> | void {
+      return findRoute(this["~rout3"], _event.req.method, _event.url.pathname);
     }
 
-    override _addRoute(_route: H3Route): void {
-      addRoute(this._rou3, _route.method, _route.route!, _route);
-      super._addRoute(_route);
+    override "~addRoute"(_route: H3Route): void {
+      addRoute(this["~rout3"], _route.method, _route.route!, _route);
+      super["~addRoute"](_route);
     }
 
     use(arg1: unknown, arg2?: unknown, arg3?: unknown): this {
@@ -204,7 +205,7 @@ export const H3 = /* @__PURE__ */ (() => {
         fn = arg1 as Middleware | H3Type;
         opts = arg2 as MiddlewareOptions;
       }
-      this._middleware.push(
+      this["~middleware"].push(
         normalizeMiddleware(fn as Middleware, { ...opts, route }),
       );
       return this;

--- a/src/types/h3.ts
+++ b/src/types/h3.ts
@@ -69,16 +69,16 @@ export type MiddlewareOptions = {
 };
 
 export declare class H3Core {
-  /** @internal */
-  _middleware: Middleware[];
-
-  /** @internal */
-  _routes: H3Route[];
-
   /**
    * H3 instance config.
    */
   readonly config: H3Config;
+
+  /** @internal */
+  "~middleware": Middleware[];
+
+  /** @internal */
+  "~routes": H3Route[];
 
   /**
    * Create a new H3 app instance.
@@ -94,33 +94,33 @@ export declare class H3Core {
    */
   fetch(_request: ServerRequest): Response | Promise<Response>;
 
+  /**
+   * An h3 compatible event handler useful to compose multiple h3 app instances.
+   */
+  handler(event: H3Event): unknown | Promise<unknown>;
+
   /** @internal */
-  _request(
+  "~request"(
     request: ServerRequest,
     context?: H3EventContext,
   ): Response | Promise<Response>;
 
   /** @internal */
-  _findRoute(_event: H3Event): MatchedRoute<H3Route> | void;
+  "~findRoute"(_event: H3Event): MatchedRoute<H3Route> | void;
 
   /** @internal */
-  _getMiddleware(
+  "~getMiddleware"(
     event: H3Event,
     route: MatchedRoute<H3Route> | undefined,
   ): Middleware[];
 
   /** @internal */
-  _addRoute(_route: H3Route): void;
-
-  /**
-   * An h3 compatible event handler useful to compose multiple h3 app instances.
-   */
-  handler(event: H3Event): unknown | Promise<unknown>;
+  "~addRoute"(_route: H3Route): void;
 }
 
 export declare class H3 extends H3Core {
   /** @internal */
-  _rou3: RouterContext<H3Route>;
+  "~rou3": RouterContext<H3Route>;
 
   /**
    * A [fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API)-compatible API allowing to fetch app routes.

--- a/test/bench/bench.impl.ts
+++ b/test/bench/bench.impl.ts
@@ -1,6 +1,6 @@
 import { compileRouter } from "rou3/compiler";
 import * as _h3src from "../../src/index.ts";
-import * as _h3nightly from "h3-nightly";
+// import * as _h3nightly from "h3-nightly";
 import { EmptyObject } from "../../src/utils/internal/obj.ts";
 
 type AppFetch = (req: Request) => Response | Promise<Response>;
@@ -10,7 +10,7 @@ export function createInstances(): Array<[string, AppFetch]> {
     ["std", std()], // (also does warmup)
     ["std-fast", stdFast()],
     ["h3", h3(_h3src)],
-    ["h3-nightly", h3(_h3nightly as any)],
+    // ["h3-nightly", h3(_h3nightly as any)],
     ["h3-compiled", h3(_h3src, true)],
     ["h3-middleware", h3Middleware(_h3src)],
   ] as const;
@@ -26,8 +26,9 @@ export function h3(lib: typeof _h3src, compiled?: boolean): AppFetch {
     })
     .post("/json", (event) => event.req.json());
   if (compiled) {
-    const findRoute = compileRouter(app._rou3);
-    app._findRoute = (event) => findRoute(event.req.method, event.url.pathname);
+    const findRoute = compileRouter(app["~rou3"]);
+    app["~findRoute"] = (event) =>
+      findRoute(event.req.method, event.url.pathname);
   }
   return app.fetch;
 }

--- a/test/mount.test.ts
+++ b/test/mount.test.ts
@@ -39,10 +39,10 @@ describeMatrix("mount", (t, { it, expect, describe }) => {
           })),
       );
 
-      expect(t.app._routes).toHaveLength(1);
-      expect(t.app._routes[0].route).toBe("/test/**:slug");
+      expect(t.app["~routes"]).toHaveLength(1);
+      expect(t.app["~routes"][0].route).toBe("/test/**:slug");
 
-      expect(t.app._middleware).toHaveLength(1);
+      expect(t.app["~middleware"]).toHaveLength(1);
 
       const res = await t.fetch("/test/123");
       expect(res.headers.get("x-test")).toBe("1");

--- a/test/route.test.ts
+++ b/test/route.test.ts
@@ -45,7 +45,7 @@ describe("defineRoute", () => {
     app.register(routePlugin);
 
     // Check that route was registered
-    const route = app._routes.find(
+    const route = app["~routes"].find(
       (r) => r.route === "/api/test" && r.method === "GET",
     );
 


### PR DESCRIPTION
Previously:

<img width="815" height="258" alt="image" src="https://github.com/user-attachments/assets/5ac0e90b-1782-46d0-9c1e-26238c71382c" />

After:

<img width="815" height="253" alt="image" src="https://github.com/user-attachments/assets/0e06c8bf-c5ad-410a-9fca-7fc4cfe1d0b5" />

(`~` props go to last)

<img width="836" height="253" alt="image" src="https://github.com/user-attachments/assets/72c35f47-c091-4c90-874e-3b19f25cc0c9" />
