### PR TITLE
types(onResponse): allow returning any value

### DIFF
--- a/src/utils/middleware.ts
+++ b/src/utils/middleware.ts
@@ -10,7 +10,7 @@ import { assertBodySize } from "./body.ts";
  * Define a middleware that runs on each request.
  */
 export function onRequest(
-  hook: (event: H3Event) => void | Promise<void>,
+  hook: (event: H3Event) => MaybePromise<void>,
 ): Middleware {
   return async function _onRequestMiddleware(event) {
     await hook(event);
@@ -23,7 +23,7 @@ export function onRequest(
  * You can return a new Response from the handler to replace the original response.
  */
 export function onResponse(
-  hook: (response: Response, event: H3Event) => MaybePromise<void | Response>,
+  hook: (response: Response, event: H3Event) => unknown,
 ): Middleware {
   return async function _onResponseMiddleware(event, next) {
     const rawBody = await next();
@@ -39,7 +39,7 @@ export function onResponse(
  * You can return a new Response from the handler to gracefully handle the error.
  */
 export function onError(
-  hook: (error: HTTPError, event: H3Event) => MaybePromise<void | unknown>,
+  hook: (error: HTTPError, event: H3Event) => unknown,
 ): Middleware {
   return async (event, next) => {
     try {


### PR DESCRIPTION
- changed `void | Promise<void>` to `MaybePromise<void>`
- changed `MaybePromise<void | Response>` to `unknown` to allow non-Response types like string, json, etc. (don't worry, `unknown` allows promise)
- changed `MaybePromise<void | unknown>` to `unknown` because its shorter and does the same

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modified middleware hook signatures for request, response, and error handling to support more flexible return types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->