### PR TITLE
fix(response): in errors prevent propagating corrupting headers

### DIFF
--- a/test/bench/bundle.test.ts
+++ b/test/bench/bundle.test.ts
@@ -38,8 +38,8 @@ describe("benchmark", () => {
         `Bundle size (H3Core): ${bundle.bytes} (gzip: ${bundle.gzipSize})`,
       );
     }
-    expect(bundle.bytes).toBeLessThanOrEqual(6200); // <6.2kb
-    expect(bundle.gzipSize).toBeLessThanOrEqual(2500); // <2.5kb
+    expect(bundle.bytes).toBeLessThanOrEqual(6300); // <6.3kb
+    expect(bundle.gzipSize).toBeLessThanOrEqual(2600); // <2.6kb
   });
 
   it("bundle size (defineHandler)", async () => {
@@ -56,8 +56,8 @@ describe("benchmark", () => {
         `Bundle size (defineHandler): ${bundle.bytes} (gzip: ${bundle.gzipSize})`,
       );
     }
-    expect(bundle.bytes).toBeLessThanOrEqual(5900); // <5.9kb
-    expect(bundle.gzipSize).toBeLessThanOrEqual(2400); // <2.4kb
+    expect(bundle.bytes).toBeLessThanOrEqual(6000); // <6.0kb
+    expect(bundle.gzipSize).toBeLessThanOrEqual(2500); // <2.5kb
   });
 });
 


### PR DESCRIPTION
While doing debetable stuff I found myself breaking a few things, but turned out to be headers that were propagating into my error responses, minimal repro would be:

```ts
import { H3, serve, HTTPError } from "h3";

const app = new H3();

app.get("/", () => {
  throw new HTTPError("Error", {
    headers: {
      "content-length": "9999",
    }
  });
});

serve(app);
```

The current `errorResponse` would blidnly merge any headers coming from `error.headers` or `error.cause.headers` and could easily endup breaking the response altogether.

Proposed fix is to create a small set of denied headers which do not get merged in the process, tho this increased bundle size about 84bytes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Error responses now filter out dangerous headers, preventing unintended header propagation in error scenarios.

* **Improvements**
  * Enhanced header handling and configuration in error response processing for more robust behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->