### PR TITLE
refactor: allow better debugging `headers are frozen`

### DIFF
--- a/src/response.ts
+++ b/src/response.ts
@@ -140,12 +140,16 @@ function mergeHeaders(base: HeadersInit, overrides: Headers, target = new Header
   return target;
 }
 
-const frozen = (name: string) => (...args: any[]) => { throw new Error(`Headers are frozen (${name} ${args.join(", ")})`) };
+const frozen =
+  (name: string) =>
+  (...args: any[]) => {
+    throw new Error(`Headers are frozen (${name} ${args.join(", ")})`);
+  };
 
 class FrozenHeaders extends Headers {
-  override set = frozen('set');
-  override append = frozen('append');
-  override delete = frozen('delete');
+  override set = frozen("set");
+  override append = frozen("append");
+  override delete = frozen("delete");
 }
 
 const emptyHeaders = /* @__PURE__ */ new FrozenHeaders({


### PR DESCRIPTION
When an empty response or JSON response is returned, H3 returns a response with with frozen headers to prevent sharing state across requests.

However currently it might but hard to investigate source of issue (when stack-traces are not helping)

This PR adds operation (set|append|delete) + arguments info to error to allow debugging better. (it costs ~20 bytes of bundle)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced error messaging when attempting to modify frozen headers, providing clearer feedback to developers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->