### PR TITLE
feat: `h3` cli

### DIFF
--- a/bin/h3.mjs
+++ b/bin/h3.mjs
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+import { main } from "srvx/cli";
+
+main({
+  usage: {
+    command: "h3",
+    docs: "https://h3.dev",
+    issues: "https://github.com/h3js/h3/issues",
+  },
+});

--- a/package.json
+++ b/package.json
@@ -5,7 +5,11 @@
   "homepage": "https://h3.dev",
   "license": "MIT",
   "repository": "h3js/h3",
+  "bin": {
+    "h3": "./bin/h3.mjs"
+  },
   "files": [
+    "bin",
     "dist"
   ],
   "type": "module",
@@ -47,7 +51,7 @@
   },
   "dependencies": {
     "rou3": "^0.7.12",
-    "srvx": "^0.10.1"
+    "srvx": "^0.11.0"
   },
   "devDependencies": {
     "@happy-dom/global-registrator": "^20.4.0",
@@ -69,6 +73,7 @@
     "express": "^5.2.1",
     "fetchdts": "^0.1.7",
     "get-port-please": "^3.2.0",
+    "h3": "link:.",
     "h3-nightly": "^2.0.0-20260123-202450-f6f152a",
     "happy-dom": "^20.4.0",
     "hono": "^4.11.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^0.7.12
         version: 0.7.12
       srvx:
-        specifier: ^0.10.1
-        version: 0.10.1
+        specifier: ^0.11.0
+        version: 0.11.0
     devDependencies:
       '@happy-dom/global-registrator':
         specifier: ^20.4.0
@@ -59,7 +59,7 @@ importers:
         version: 2.0.0
       crossws:
         specifier: ^0.4.4
-        version: 0.4.4(srvx@0.10.1)
+        version: 0.4.4(srvx@0.11.0)
       elysia:
         specifier: ^1.4.22
         version: 1.4.22(@sinclair/typebox@0.34.41)(exact-mirror@0.2.2(@sinclair/typebox@0.34.41))(file-type@21.0.0)(openapi-types@12.1.3)(typescript@5.9.3)
@@ -75,9 +75,12 @@ importers:
       get-port-please:
         specifier: ^3.2.0
         version: 3.2.0
+      h3:
+        specifier: 'link:'
+        version: 'link:'
       h3-nightly:
         specifier: ^2.0.0-20260123-202450-f6f152a
-        version: 2.0.0-20260123-202450-f6f152a(crossws@0.4.4(srvx@0.10.1))
+        version: 2.0.0-20260123-202450-f6f152a(crossws@0.4.4(srvx@0.11.0))
       happy-dom:
         specifier: ^20.4.0
         version: 20.4.0
@@ -1833,6 +1836,11 @@ packages:
     engines: {node: '>=20.16.0'}
     hasBin: true
 
+  srvx@0.11.0:
+    resolution: {integrity: sha512-pKIOmjuhgkF2uWfEt0pW5a2OR5Qm2LMBD/lCrgf1uLgzMLoRT559rby1pheQBRmlD7TNJqzmVmok3wyOb49wug==}
+    engines: {node: '>=20.16.0'}
+    hasBin: true
+
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
@@ -2840,9 +2848,9 @@ snapshots:
 
   cookie@1.1.1: {}
 
-  crossws@0.4.4(srvx@0.10.1):
+  crossws@0.4.4(srvx@0.11.0):
     optionalDependencies:
-      srvx: 0.10.1
+      srvx: 0.11.0
 
   csstype@3.2.3: {}
 
@@ -3087,12 +3095,12 @@ snapshots:
 
   gopd@1.2.0: {}
 
-  h3-nightly@2.0.0-20260123-202450-f6f152a(crossws@0.4.4(srvx@0.10.1)):
+  h3-nightly@2.0.0-20260123-202450-f6f152a(crossws@0.4.4(srvx@0.11.0)):
     dependencies:
       rou3: 0.7.12
       srvx: 0.10.1
     optionalDependencies:
-      crossws: 0.4.4(srvx@0.10.1)
+      crossws: 0.4.4(srvx@0.11.0)
 
   happy-dom@20.4.0:
     dependencies:
@@ -3572,6 +3580,8 @@ snapshots:
   source-map-js@1.2.1: {}
 
   srvx@0.10.1: {}
+
+  srvx@0.11.0: {}
 
   stackback@0.0.2: {}
 


### PR DESCRIPTION
This PR adds support for `h3` cli powered by existing srvx dep.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added h3 command-line interface tool

* **Chores**
  * Updated srvx dependency to version 0.11.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->