### PR TITLE
refactor(tracing): rename tracing channel `.fetch` to `.request`

### DIFF
--- a/src/tracing.ts
+++ b/src/tracing.ts
@@ -40,7 +40,7 @@ export function tracingPlugin(traceOpts?: TracingPluginOptions): H3Plugin {
       return;
     }
 
-    const requestHandlerChannel = tracingChannel("h3.fetch");
+    const requestHandlerChannel = tracingChannel("h3.request");
 
     function wrapMiddleware(middleware: MaybeTracedMiddleware): Middleware {
       if (middleware.__traced__ || traceOpts?.traceMiddleware === false) {

--- a/test/tracing.test.ts
+++ b/test/tracing.test.ts
@@ -16,7 +16,7 @@ type TracingEvent = {
 function createTracingListener() {
   const events: TracingEvent[] = [];
 
-  const tracingCh = tracingChannel("h3.fetch");
+  const tracingCh = tracingChannel("h3.request");
 
   const startHandler = (message: any) => {
     events.push({ start: { data: message } });
@@ -121,7 +121,7 @@ describeMatrix(
       }
     });
 
-    it("tracing:h3.fetch:asyncStart/asyncEnd fire for async handlers", async () => {
+    it("tracing:h3.request:asyncStart/asyncEnd fire for async handlers", async () => {
       const listener = createTracingListener();
 
       try {
@@ -151,7 +151,7 @@ describeMatrix(
       }
     });
 
-    it("tracing:h3.fetch:error fires when handler throws", async () => {
+    it("tracing:h3.request:error fires when handler throws", async () => {
       const listener = createTracingListener();
 
       // Disable the test error handler so we can see the tracing error event


### PR DESCRIPTION
We discussed that `.request` fits it more nicely than `fetch` to avoid confusion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the diagnostics channel used for request tracing to emit traced events on the proper channel name, ensuring accurate trace information when monitoring application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->