### PR TITLE
docs: add `unjwt` community library entry

### DIFF
--- a/docs/2.utils/99.community.md
+++ b/docs/2.utils/99.community.md
@@ -38,3 +38,9 @@ This section is placeholder for any new H3 version 2 compatible community librar
 Laravel-style routing system for H3 and Express.js. Clean route definitions, middleware support, and controller bindings with full TypeScript support.
 
 :read-more{to="https://github.com/toneflix/clear-router"}
+
+## `unjwt`
+
+`unjwt` is a collection of low-level JWT utilities (JWS, JWE, JWK) built on the Web Crypto API, with zero runtime dependencies. It includes a dedicated H3 v2 adapter for header and cookie-based session management with support for encrypted (JWE) and signed (JWS) tokens.
+
+:read-more{to="https://github.com/sandros94/unjwt"}


### PR DESCRIPTION
Finally adding [`unjwt`](https://github.com/sandros94/unjwt) to the community section!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new community library entry for JWT utilities featuring Web Crypto API support, JWS/JWE/JWK capabilities, and zero runtime dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->